### PR TITLE
Partially merge contents of unstable/gui/pict

### DIFF
--- a/pict-doc/pict/scribblings/color.scrbl
+++ b/pict-doc/pict/scribblings/color.scrbl
@@ -1,0 +1,56 @@
+#lang scribble/manual
+
+@(require (for-label pict/color)
+          scribble/eval)
+
+@(define the-eval (make-base-eval))
+@(the-eval '(require pict pict/color))
+
+@title{Color Helpers}
+
+@defmodule[pict/color]
+
+
+@deftogether[(
+@defproc[(red [pict pict?]) pict?]
+@defproc[(orange [pict pict?]) pict?]
+@defproc[(yellow [pict pict?]) pict?]
+@defproc[(green [pict pict?]) pict?]
+@defproc[(blue [pict pict?]) pict?]
+@defproc[(purple [pict pict?]) pict?]
+@defproc[(black [pict pict?]) pict?]
+@defproc[(brown [pict pict?]) pict?]
+@defproc[(gray [pict pict?]) pict?]
+@defproc[(white [pict pict?]) pict?]
+@defproc[(cyan [pict pict?]) pict?]
+@defproc[(magenta [pict pict?]) pict?]
+)]{
+
+These functions apply appropriate colors to picture @racket[p].
+
+@examples[#:eval the-eval
+(red (disk 20))
+]
+}
+
+@deftogether[(
+@defproc[(light [color color/c]) color/c]
+@defproc[(dark [color color/c]) color/c]
+)]{
+
+These functions produce ligher or darker versions of a color.
+
+@examples[#:eval the-eval
+(hc-append (colorize (disk 20) "red")
+           (colorize (disk 20) (dark "red"))
+           (colorize (disk 20) (light "red")))
+]
+}
+
+@defthing[color/c flat-contract?]{
+
+This contract recognizes color strings, @racket[color%] instances, and RGB color
+lists.
+}
+
+@(close-eval the-eval)

--- a/pict-doc/pict/scribblings/conditional.scrbl
+++ b/pict-doc/pict/scribblings/conditional.scrbl
@@ -88,4 +88,15 @@ to @racket[lbl-superimpose].
 
 }
 
+@deftogether[(
+@defproc[(show [pict pict?] [show? truth/c #t]) pict?]
+@defproc[(hide [pict pict?] [hide? truth/c #t]) pict?]
+)]{
+
+These functions conditionally show or hide an image, essentially choosing
+between @racket[pict] and @racket[(ghost pict)].  The only difference between
+the two is the default behavior and the opposite meaning of the @racket[show?]
+and @racket[hide?] booleans.  Both functions are provided for mnemonic purposes.
+}
+
 @(close-eval the-eval)

--- a/pict-doc/pict/scribblings/conditional.scrbl
+++ b/pict-doc/pict/scribblings/conditional.scrbl
@@ -46,7 +46,7 @@ invisible images using @racket[combine-expr], defaulting to
 
 @examples[#:eval the-eval
 (let ([f (lambda (x)
-           (pict-cond
+           (pict-cond #:combine cc-superimpose
              [(eq? x 'circle) (circle 20)]
              [(eq? x 'disk) (disk 40)]
              [(eq? x 'text) (text "ok" null 20)]))])

--- a/pict-doc/pict/scribblings/conditional.scrbl
+++ b/pict-doc/pict/scribblings/conditional.scrbl
@@ -78,16 +78,6 @@ to @racket[lbl-superimpose].
 ]
 }
 
-@defform/subs[(pict-match test-expr maybe-combine [pattern pict-expr] ...)
-              ([maybe-combine code:blank (code:line #:combine combine-expr)])]{
-
-Chooses a @racket[pict-expr] based on @racket[test-expr] and each
-@racket[pattern], similarly to @racket[match].  Combines the chosen, visible
-image with the other, invisible images using @racket[combine-expr], defaulting
-to @racket[lbl-superimpose].
-
-}
-
 @deftogether[(
 @defproc[(show [pict pict?] [show? truth/c #t]) pict?]
 @defproc[(hide [pict pict?] [hide? truth/c #t]) pict?]

--- a/pict-doc/pict/scribblings/conditional.scrbl
+++ b/pict-doc/pict/scribblings/conditional.scrbl
@@ -1,0 +1,91 @@
+#lang scribble/manual
+
+@(require (for-label pict/conditional)
+          scribble/eval)
+
+@(define the-eval (make-base-eval))
+@(the-eval '(require pict pict/conditional))
+
+@title{Conditional Combinations}
+
+@defmodule[pict/conditional]
+
+These pict control flow operators decide which pict of several to use.  All
+branches are evaluated; the resulting pict is a combination of the pict chosen
+by normal conditional flow with @racket[ghost] applied to all the other picts.
+The result is a picture large enough to accommodate each alternative, but showing
+only the chosen one.  This is useful for staged slides, as the pict chosen may
+change with each slide but its size and position will not.
+
+@defform/subs[(pict-if maybe-combine test-expr then-expr else-expr)
+              ([maybe-combine code:blank (code:line #:combine combine-expr)])]{
+
+Chooses either @racket[then-expr] or @racket[else-expr] based on
+@racket[test-expr], similarly to @racket[if].  Combines the chosen, visible
+image with the other, invisible image using @racket[combine-expr], defaulting to
+@racket[pict-combine].
+
+@examples[#:eval the-eval
+(let ([f (lambda (x)
+           (pict-if x
+                    (disk 20)
+                    (disk 40)))])
+  (hc-append 10
+             (frame (f #t))
+             (frame (f #f))))
+]
+}
+
+@defform/subs[(pict-cond maybe-combine [test-expr pict-expr] ...)
+              ([maybe-combine code:blank (code:line #:combine combine-expr)])]{
+
+Chooses a @racket[pict-expr] based on the first successful @racket[test-expr],
+similarly to @racket[cond].  Combines the chosen, visible image with the other,
+invisible images using @racket[combine-expr], defaulting to
+@racket[pict-combine].
+
+@examples[#:eval the-eval
+(let ([f (lambda (x)
+           (pict-cond
+             [(eq? x 'circle) (circle 20)]
+             [(eq? x 'disk) (disk 40)]
+             [(eq? x 'text) (text "ok" null 20)]))])
+  (hc-append 10
+             (frame (f 'circle))
+             (frame (f 'disk))
+             (frame (f 'text))))
+]
+}
+
+@defform/subs[(pict-case test-expr maybe-combine [literals pict-expr] ...)
+              ([maybe-combine code:blank (code:line #:combine combine-expr)])]{
+
+Chooses a @racket[pict-expr] based on @racket[test-expr] and each list of
+@racket[literals], similarly to @racket[case].  Combines the chosen, visible
+image with the other, invisible images using @racket[combine-expr], defaulting
+to @racket[pict-combine].
+
+@examples[#:eval the-eval
+(let ([f (lambda (x)
+           (pict-case x
+             [(circle) (circle 20)]
+             [(disk) (disk 40)]
+             [(text) (text "ok" null 20)]))])
+  (hc-append 10
+             (frame (f 'circle))
+             (frame (f 'disk))
+             (frame (f 'text))))
+]
+}
+
+@defform/subs[(pict-match test-expr maybe-combine [pattern pict-expr] ...)
+              ([maybe-combine code:blank (code:line #:combine combine-expr)])]{
+
+Chooses a @racket[pict-expr] based on @racket[test-expr] and each
+@racket[pattern], similarly to @racket[match].  Combines the chosen, visible
+image with the other, invisible images using @racket[combine-expr], defaulting
+to @racket[pict-combine].
+
+}
+
+@(close-eval the-eval)

--- a/pict-doc/pict/scribblings/conditional.scrbl
+++ b/pict-doc/pict/scribblings/conditional.scrbl
@@ -23,7 +23,7 @@ change with each slide but its size and position will not.
 Chooses either @racket[then-expr] or @racket[else-expr] based on
 @racket[test-expr], similarly to @racket[if].  Combines the chosen, visible
 image with the other, invisible image using @racket[combine-expr], defaulting to
-@racket[pict-combine].
+@racket[lbl-superimpose].
 
 @examples[#:eval the-eval
 (let ([f (lambda (x)
@@ -42,7 +42,7 @@ image with the other, invisible image using @racket[combine-expr], defaulting to
 Chooses a @racket[pict-expr] based on the first successful @racket[test-expr],
 similarly to @racket[cond].  Combines the chosen, visible image with the other,
 invisible images using @racket[combine-expr], defaulting to
-@racket[pict-combine].
+@racket[lbl-superimpose].
 
 @examples[#:eval the-eval
 (let ([f (lambda (x)
@@ -63,7 +63,7 @@ invisible images using @racket[combine-expr], defaulting to
 Chooses a @racket[pict-expr] based on @racket[test-expr] and each list of
 @racket[literals], similarly to @racket[case].  Combines the chosen, visible
 image with the other, invisible images using @racket[combine-expr], defaulting
-to @racket[pict-combine].
+to @racket[lbl-superimpose].
 
 @examples[#:eval the-eval
 (let ([f (lambda (x)
@@ -84,7 +84,7 @@ to @racket[pict-combine].
 Chooses a @racket[pict-expr] based on @racket[test-expr] and each
 @racket[pattern], similarly to @racket[match].  Combines the chosen, visible
 image with the other, invisible images using @racket[combine-expr], defaulting
-to @racket[pict-combine].
+to @racket[lbl-superimpose].
 
 }
 

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -474,7 +474,10 @@ argument for consistency with the other functions.}
                                                'xor-dot 'xor-long-dash 'xor-short-dash 
                                                'xor-dot-dash)
                                'solid]
-                      [#:under? under? any/c #f])
+                      [#:under? under? any/c #f]
+                      [#:label label pict? (blank)]
+                      [#:x-adjust-label x-adjust-label real? 0]
+                      [#:y-adjust-label y-adjust-label real? 0])
             pict?]
            [(pin-arrow-line [arrow-size real?] [pict pict?]
                       [src pict-path?]
@@ -494,6 +497,9 @@ argument for consistency with the other functions.}
                                                'xor-dot-dash)
                                'solid]
                       [#:under? under? any/c #f]
+                      [#:label label pict? (blank)]
+                      [#:x-adjust-label x-adjust-label real? 0]
+                      [#:y-adjust-label y-adjust-label real? 0]
                       [#:solid? solid? any/c #t]
 		      [#:hide-arrowhead? hide-arrowhead? any/c #f])
             pict?]
@@ -514,6 +520,9 @@ argument for consistency with the other functions.}
                                                'xor-dot 'xor-long-dash 'xor-short-dash 
                                                'xor-dot-dash)]
                       [#:under? under? any/c #f]
+                      [#:label label pict? (blank)]
+                      [#:x-adjust-label x-adjust-label real? 0]
+                      [#:y-adjust-label y-adjust-label real? 0]
                       [#:solid? solid? any/c #t]
 		      [#:hide-arrowhead? hide-arrowhead? any/c #f])
             pict?])]{
@@ -551,6 +560,9 @@ When the @racket[hide-arrowhead?] argument is a true value, then space
 for an arrowhead is kept around the line, but the arrowhead itself is
 not drawn.
 
+When the @racket[label] argument is non-false, the given pict is used as a
+label for the line, and moved by (@racket[x-adjust-label], @racket[y-adjust-label]).
+
 @defexamples[#:eval ss-eval
   (define pict-a (rectangle 40 40))
   (define pict-b (circle 40))
@@ -563,7 +575,8 @@ not drawn.
                   pict-b lc-find
                   #:line-width 3
                   #:style 'long-dash
-                  #:color "medium goldenrod")
+                  #:color "medium goldenrod"
+                  #:label (text "From Square to Circle"))
   (pin-arrows-line 30 combined
                    pict-a rc-find
                    pict-b lc-find

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -338,8 +338,9 @@ If @racket[draw-border?] is @racket[#f], then the pen is set to be transparent
 before drawing the ellipse.
 The @racket[color], @racket[border-color] and @racket[border-width] arguments
 control the fill color, color of the border, and width of the border,
-respectively. Values of @racket[#f] use the color and width of the current pen
-(for the border) or brush (for the fill color).
+respectively.
+If these arguments are @racket[#f], values set using @racket[linewidth] and
+@racket[colorize] are used instead.
 Passing non-@racket[#f] values as @racket[border-color] or @racket[border-width]
 when @racket[draw-border?] is @racket[#f] results in a contract violation.
 
@@ -369,8 +370,9 @@ If @racket[draw-border?] is @racket[#f], then the pen is set to be transparent
 before drawing the rectangle.
 The @racket[color], @racket[border-color] and @racket[border-width] arguments
 control the fill color, color of the border, and width of the border,
-respectively. Values of @racket[#f] use the color and width of the current pen
-(for the border) or brush (for the fill color).
+respectively.
+If these arguments are @racket[#f], values set using @racket[linewidth] and
+@racket[colorize] are used instead.
 Passing non-@racket[#f] values as @racket[border-color] or @racket[border-width]
 when @racket[draw-border?] is @racket[#f] results in a contract violation.
 
@@ -412,8 +414,9 @@ If @racket[draw-border?] is @racket[#f], then the pen is set to be transparent
 before drawing the rectangle.
 The @racket[color], @racket[border-color] and @racket[border-width] arguments
 control the fill color, color of the border, and width of the border,
-respectively. Values of @racket[#f] use the color and width of the current pen
-(for the border) or brush (for the fill color).
+respectively.
+If these arguments are @racket[#f], values set using @racket[linewidth] and
+@racket[colorize] are used instead.
 Passing non-@racket[#f] values as @racket[border-color] or @racket[border-width]
 when @racket[draw-border?] is @racket[#f] results in a contract violation.
 

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -973,6 +973,10 @@ pict with the same shape and location.}
 
 @; ----------------------------------------
 
+@include-section["conditional.scrbl"]
+
+@; ----------------------------------------
+
 @include-section["tree-layout.scrbl"]
 
 @; ----------------------------------------

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -969,6 +969,10 @@ pict with the same shape and location.}
 
 @; ----------------------------------------
 
+@include-section["color.scrbl"]
+
+@; ----------------------------------------
+
 @include-section["tree-layout.scrbl"]
 
 @; ----------------------------------------

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -747,17 +747,26 @@ scale while drawing the original @racket[pict].
 
 }
 
-@defproc*[([(scale-to-fit [pict pict?] [size-pict pict?]) pict?]
-           [(scale-to-fit [pict pict?] [width real?] [height real?]) pict?])]{
+@defproc*[([(scale-to-fit [pict pict?] [size-pict pict?]
+                          [#:mode mode (or/c 'preserve 'inset 'distort) 'preserve])
+                          pict?]
+           [(scale-to-fit [pict pict?] [width real?] [height real?]
+                          [#:mode mode (or/c 'preserve 'inset 'distort) 'preserve])
+                          pict?])]{
   Scales @racket[pict] so that it fits within the bounding box of
          @racket[size-pict] (if two arguments are supplied) or
          into a box of size @racket[width] by @racket[height] 
          (if three arguments are supplied).
-         
-         The aspect ratio of the pict is preserved, so the resulting pict
-         will have either the width or the height of the @racket[size-pict]
-         (or @racket[width] by @racket[height] box), but not necessarily
-         both.
+
+         If @racket[mode] is @racket['preserve], the width and height are
+         scaled by the same factor so @racket[pict]'s aspect ratio is
+         preserved; the result's bounding box may be smaller than
+         @racket[width] by @racket[height].
+         If @racket[mode] is @racket['inset], the aspect ratio is preserved as
+         with @racket['preserve], but the resulting pict is centered in a
+         bounding box of exactly @racket[width] by @racket[height].
+         If @racket[mode] is @racket['distort], the width and height are scaled
+         separately.
 }
 
 

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -340,6 +340,8 @@ The @racket[color], @racket[border-color] and @racket[border-width] arguments
 control the fill color, color of the border, and width of the border,
 respectively. Values of @racket[#f] use the color and width of the current pen
 (for the border) or brush (for the fill color).
+Passing non-@racket[#f] values as @racket[border-color] or @racket[border-width]
+when @racket[draw-border?] is @racket[#f] results in a contract violation.
 
 @examples[#:eval ss-eval
   (ellipse 40 30)
@@ -369,6 +371,8 @@ The @racket[color], @racket[border-color] and @racket[border-width] arguments
 control the fill color, color of the border, and width of the border,
 respectively. Values of @racket[#f] use the color and width of the current pen
 (for the border) or brush (for the fill color).
+Passing non-@racket[#f] values as @racket[border-color] or @racket[border-width]
+when @racket[draw-border?] is @racket[#f] results in a contract violation.
 
 @examples[#:eval ss-eval
   (rectangle 50 50)
@@ -410,6 +414,8 @@ The @racket[color], @racket[border-color] and @racket[border-width] arguments
 control the fill color, color of the border, and width of the border,
 respectively. Values of @racket[#f] use the color and width of the current pen
 (for the border) or brush (for the fill color).
+Passing non-@racket[#f] values as @racket[border-color] or @racket[border-width]
+when @racket[draw-border?] is @racket[#f] results in a contract violation.
 
 @examples[#:eval ss-eval
   (rounded-rectangle 40 40 -0.3 #:angle (/ pi 4))

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -312,48 +312,83 @@ override settings supplied by the context.
   (frame (circle 30) #:color "chartreuse" #:line-width 3)
 ]}
 
-@defproc*[([(ellipse [w real?] [h real?]) pict?]
-           [(circle [diameter real?]) pict?]
-           [(filled-ellipse [w real?] [h real?] [#:draw-border? draw-border? any/c #t]) pict?]
+@defproc*[([(ellipse [w real?] [h real?]
+                     [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                     [#:border-width border-width (or/c #f real?) #f])
+                     pict?]
+           [(circle [diameter real?]
+                    [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                    [#:border-width border-width (or/c #f real?) #f])
+                    pict?]
+           [(filled-ellipse [w real?] [h real?] [#:draw-border? draw-border? any/c #t]
+                            [#:color color (or/c #f string? (is-a?/c color<%>)) #f]
+                            [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                            [#:border-width border-width (or/c #f real?) #f])
+                            pict?]
            [(disk [diameter (and/c rational? (not/c negative?))]
-                  [#:draw-border? draw-border? any/c #t]) pict?])]{
+                  [#:draw-border? draw-border? any/c #t]
+                  [#:color color (or/c #f string? (is-a?/c color<%>)) #f]
+                  [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                  [#:border-width border-width (or/c #f real?) #f])
+                  pict?])]{
 
 Unfilled and filled ellipses.
 
 If @racket[draw-border?] is @racket[#f], then the pen is set to be transparent
 before drawing the ellipse.
+The @racket[color], @racket[border-color] and @racket[border-width] arguments
+control the fill color, color of the border, and width of the border,
+respectively. Values of @racket[#f] use the color and width of the current pen
+(for the border) or brush (for the fill color).
 
 @examples[#:eval ss-eval
   (ellipse 40 30)
   (circle 30)
   (filled-ellipse 30 40)
   (disk 30)
+  (disk 40 #:color "Chartreuse" #:border-color "Medium Aquamarine" #:border-width 5)
 ]}
 
-@defproc*[([(rectangle [w real?] [h real?]) pict?]
+@defproc*[([(rectangle [w real?] [h real?]
+                       [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                       [#:border-width border-width (or/c #f real?)])
+                       pict?]
            [(filled-rectangle [w real?]
                               [h real?]
-                              [#:draw-border? draw-border? any/c #t])
+                              [#:draw-border? draw-border? any/c #t]
+                              [#:color color (or/c #f string? (is-a?/c color<%>)) #f]
+                              [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                              [#:border-width border-width (or/c #f real?)])
             pict?])]{
 
 Unfilled and filled rectangles.
 
 If @racket[draw-border?] is @racket[#f], then the pen is set to be transparent
 before drawing the rectangle.
+The @racket[color], @racket[border-color] and @racket[border-width] arguments
+control the fill color, color of the border, and width of the border,
+respectively. Values of @racket[#f] use the color and width of the current pen
+(for the border) or brush (for the fill color).
 
 @examples[#:eval ss-eval
   (rectangle 50 50)
   (filled-rectangle 50 80)
+  (filled-rectangle 60 70 #:color "Thistle" #:border-color "Gainsboro" #:border-width 10)
 ]}
 
 @defproc*[([(rounded-rectangle [w real?] [h real?] 
                                [corner-radius real? -0.25]
-                               [#:angle angle real? 0])
+                               [#:angle angle real? 0]
+                               [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                               [#:border-width border-width (or/c #f real?)])
             pict?]
            [(filled-rounded-rectangle [w real?] [h real?]
                                       [corner-radius real? -0.25]
                                       [#:angle angle real? 0] 
-                                      [#:draw-border? draw-border? any/c #t])
+                                      [#:draw-border? draw-border? any/c #t]
+                                      [#:color color (or/c #f string? (is-a?/c color<%>)) #f]
+                                      [#:border-color border-color (or/c #f string? (is-a?/c color<%>)) #f]
+                                      [#:border-width border-width (or/c #f real?)])
             pict?])]{
 
 Unfilled and filled rectangles with rounded corners.  The
@@ -371,10 +406,15 @@ rotated, in radians.
 
 If @racket[draw-border?] is @racket[#f], then the pen is set to be transparent
 before drawing the rectangle.
+The @racket[color], @racket[border-color] and @racket[border-width] arguments
+control the fill color, color of the border, and width of the border,
+respectively. Values of @racket[#f] use the color and width of the current pen
+(for the border) or brush (for the fill color).
 
 @examples[#:eval ss-eval
   (rounded-rectangle 40 40 -0.3 #:angle (/ pi 4))
   (filled-rounded-rectangle 50 40)
+  (filled-rounded-rectangle 70 30 #:color "Burlywood" #:border-color "Bisque" #:border-width 8)
 ]}
 
 @defproc[(bitmap [img (or/c path-string?

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -1035,6 +1035,10 @@ pict with the same shape and location.}
 
 @; ----------------------------------------
 
+@include-section["shadow.scrbl"]
+
+@; ----------------------------------------
+
 @include-section["conditional.scrbl"]
 
 @; ----------------------------------------

--- a/pict-doc/pict/scribblings/shadow.scrbl
+++ b/pict-doc/pict/scribblings/shadow.scrbl
@@ -1,0 +1,111 @@
+#lang scribble/manual
+
+@(require (for-label pict/shadow)
+          scribble/eval)
+
+@(define the-eval (make-base-eval))
+@(the-eval '(require pict pict/shadow))
+
+@title{Shadows}
+
+@defmodule[pict/shadow]
+
+These pict transformations add shadows or blurring in various shapes and
+forms.
+
+@defproc[(blur [p pict?]
+               [h-radius (and/c real? (not/c negative?))]
+               [v-radius (and/c real? (not/c negative?)) h-radius])
+         pict?]{
+
+Blurs @racket[p] using an iterated box blur that approximates a
+gaussian blur. The @racket[h-radius] and @racket[v-radius] arguments
+control the strength of the horizontal and vertical components of the
+blur, respectively. They are given in terms of pict units, which may
+not directly correspond to screen pixels.
+
+The @racket[blur] function takes work proportional to
+@racketblock[(* (pict-width p) (pict-height p))]
+but it may be sped up by a factor of up to @racket[(processor-count)]
+due to the use of @racket[future]s.
+
+@examples[#:eval the-eval
+(blur (text "blur" null 40) 5)
+(blur (text "more blur" null 40) 10)
+(blur (text "much blur" null 40) 20)
+(blur (text "horiz. blur" null 40) 10 0)
+]
+The resulting pict has the same bounding box as @racket[p], so when
+picts are automatically @racket[clip]ped (as in Scribble documents),
+the pict should be @racket[inset] by the blur radius.
+@examples[#:eval the-eval
+(inset (blur (text "more blur" null 40) 10) 10)
+]
+}               
+
+@defproc[(shadow [p pict?]
+                 [radius (and/c real? (not/c negative?))]
+                 [dx real? 0]
+                 [dy real? dx]
+                 [#:color color (or/c #f string? (is-a?/c color%)) #f]
+                 [#:shadow-color shadow-color (or/c #f string? (is-a?/c color%)) #f])
+         pict?]{
+
+Creates a shadow effect by superimposing @racket[p] over a
+blurred version of @racket[p]. The shadow is offset from @racket[p] by
+(@racket[dx], @racket[dy]) units.
+
+If @racket[color] is not @racket[#f], the foreground part is
+@racket[(colorize p color)]; otherwise it is just @racket[p]. If
+@racket[shadow-color] is not @racket[#f], the shadow part is produced
+by blurring @racket[(colorize p shadow-color)]; otherwise it is
+produced by blurring @racket[p].
+
+The resulting pict has the same bounding box as @racket[p].
+
+@examples[#:eval the-eval
+(inset (shadow (text "shadow" null 50) 10) 10)
+(inset (shadow (text "shadow" null 50) 10 5) 10)
+(inset (shadow (text "shadow" null 50) 
+               5 0 2 #:color "white" #:shadow-color "red")
+       10)
+]
+}
+
+@defproc[(shadow-frame [pict pict?] ...
+                       [#:sep separation real? 5]
+                       [#:margin margin real? 20]
+                       [#:background-color bg-color (or/c string? (is-a?/c color%)) "white"]
+                       [#:frame-color frame-color (or/c string? (is-a?/c color%)) "gray"]
+                       [#:frame-line-width frame-line-width (or/c real? #f) 0]
+                       [#:shadow-side-length shadow-side-length real? 4]
+                       [#:shadow-top-y-offset shadow-top-y-offset real? 10]
+                       [#:shadow-bottom-y-offset shadow-bottom-y-offset real? 4]
+                       [#:shadow-descent shadow-descent (and/c real? (not/c negative?)) 40]
+                       [#:shadow-alpha-factor shadow-alpha-factor real? 3/4]
+                       [#:blur blur-radius (and/c real? (not/c negative?)) 20])
+         pict?]{
+
+Surrounds the @racket[pict]s with a rectangular frame that casts a
+symmetric ``curled paper'' shadow.
+
+The @racket[pict]s are vertically appended with @racket[separation]
+space between them. They are placed on a rectangular background of
+solid @racket[bg-color] with @racket[margin] space on all sides. A
+frame of @racket[frame-color] and @racket[frame-line-width] is added
+around the rectangle. The rectangle casts a shadow that extends
+@racket[shadow-side-length] to the left and right, starts
+@racket[shadow-top-y-offset] below the top of the rectangle and
+extends to @racket[shadow-bottom-y-offset] below the bottom of the
+rectangle in the center and an additional @racket[shadow-descent]
+below that on the sides. The shadow is painted using a linear
+gradient; @racket[shadow-alpha-factor] determines its density at the
+center. Finally, the shadow is blurred by @racket[blur-radius]; all
+previous measurements are pre-blur measurements.
+
+@examples[#:eval the-eval
+(shadow-frame (text "text in a nifty frame" null 60))
+]
+}
+
+@(close-eval the-eval)

--- a/pict-lib/info.rkt
+++ b/pict-lib/info.rkt
@@ -12,4 +12,4 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.3")
+(define version "1.4")

--- a/pict-lib/pict/color.rkt
+++ b/pict-lib/pict/color.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+
+(require racket/class racket/contract racket/draw
+         pict)
+
+(define color/c
+  (or/c string? ;; might be faster
+        ;;(and/c string? (lambda (s) (send the-color-database find-color s)))
+        (is-a?/c color%)
+        (list/c byte? byte? byte?)))
+
+(provide/contract
+ [color/c flat-contract?]
+ [red     (-> pict? pict?)]
+ [orange  (-> pict? pict?)]
+ [yellow  (-> pict? pict?)]
+ [green   (-> pict? pict?)]
+ [blue    (-> pict? pict?)]
+ [purple  (-> pict? pict?)]
+ [black   (-> pict? pict?)]
+ [brown   (-> pict? pict?)]
+ [gray    (-> pict? pict?)]
+ [white   (-> pict? pict?)]
+ [cyan    (-> pict? pict?)]
+ [magenta (-> pict? pict?)]
+ [light (-> color/c color/c)]
+ [dark (-> color/c color/c)])
+
+(define-syntax-rule (define-colors name ...)
+  (begin (define (name pict) (colorize pict (symbol->string 'name))) ...))
+
+(define-colors
+  red orange yellow green blue purple
+  black brown gray white cyan magenta)
+
+(define (light c) (scale-color 2 c))
+(define (dark c) (scale-color 1/2 c))

--- a/pict-lib/pict/conditional.rkt
+++ b/pict-lib/pict/conditional.rkt
@@ -72,19 +72,6 @@
        (pict-case test #:combine #,(syntax-parameter-value #'pict-combine)
                   [literals expr] ...))]))
 
-(define-syntax (pict-match stx)
-  (syntax-case stx ()
-    [(_ test #:combine combine [pattern expr] ...)
-     (with-syntax ([(pict ...) (generate-temporaries #'(expr ...))])
-       (syntax/loc stx
-         (let ([pict expr] ...)
-           (combine (match test [pattern pict] ... [_ (blank 0 0)])
-                    (ghost pict) ...))))]
-    [(_ test [pattern expr] ...)
-     (quasisyntax/loc stx
-       (pict-match test #:combine #,(syntax-parameter-value #'pict-combine)
-                   [pattern expr] ...))]))
-
 (define (hide pict [hide? #t])
   (if hide? (ghost pict) pict))
 

--- a/pict-lib/pict/conditional.rkt
+++ b/pict-lib/pict/conditional.rkt
@@ -1,0 +1,92 @@
+#lang racket/base
+
+(require pict
+         racket/contract/base
+         racket/stxparam
+         (for-syntax racket/base))
+
+(provide/contract
+ [hide (->* [pict?] [any/c] pict?)]
+ [show (->* [pict?] [any/c] pict?)])
+(provide pict-if pict-cond pict-case pict-match)
+
+;; The original API in unstable/gui/pict provided a syntax parameter to control
+;; the default combiner. This made the API more complex, and potentially scary
+;; due to its use of a high-powered features. To keep things simpler, the
+;; pict/conditional API does not expose those, but they need to be exposed via
+;; unstable/gui/pict for backwards compatibility.
+(module params racket/base
+  (require racket/splicing racket/stxparam pict
+           (for-syntax racket/base))
+  (provide pict-combine with-pict-combine)
+  (define-syntax-parameter pict-combine #'ltl-superimpose)
+  (define-syntax-rule (with-pict-combine combine body ...)
+    (splicing-syntax-parameterize
+     ([pict-combine #'combine])
+     body ...)))
+
+(require (submod "." params))
+
+(define-syntax (pict-if stx)
+  (syntax-case stx ()
+    [(_ #:combine combine test success failure)
+     (syntax/loc stx
+       (let* ([result test])
+         (combine (show success result)
+                  (hide failure result))))]
+    [(_ test success failure)
+     (quasisyntax/loc stx
+       (pict-if #:combine #,(syntax-parameter-value #'pict-combine)
+                test success failure))]))
+
+(define-syntax (pict-cond stx)
+  (syntax-case stx (else)
+    [(_ #:combine combine [test expr] ... [else default])
+     (with-syntax ([(pict ...) (generate-temporaries #'(expr ...))])
+       (syntax/loc stx
+         (let ([pict expr] ... [final default])
+           (combine (cond [test pict] ... [else final])
+                    (ghost pict) ... (ghost final)))))]
+    [(_ #:combine combine [test pict] ...)
+     (syntax/loc stx
+       (pict-cond #:combine combine [test pict] ... [else (blank 0 0)]))]
+    [(_ [test expr] ...)
+     (quasisyntax/loc stx
+       (pict-cond #:combine #,(syntax-parameter-value #'pict-combine)
+                  [test expr] ...))]))
+
+(define-syntax (pict-case stx)
+  (syntax-case stx (else)
+    [(_ test #:combine combine [literals expr] ... [else default])
+     (with-syntax ([(pict ...) (generate-temporaries #'(expr ...))])
+       (syntax/loc stx
+         (let ([pict expr] ... [final default])
+           (combine (case test [literals pict] ... [else final])
+                    (ghost pict) ... (ghost final)))))]
+    [(_ test #:combine combine [literals expr] ...)
+     (syntax/loc stx
+       (pict-case test #:combine combine
+                  [literals expr] ... [else (blank 0 0)]))]
+    [(_ test [literals expr] ...)
+     (quasisyntax/loc stx
+       (pict-case test #:combine #,(syntax-parameter-value #'pict-combine)
+                  [literals expr] ...))]))
+
+(define-syntax (pict-match stx)
+  (syntax-case stx ()
+    [(_ test #:combine combine [pattern expr] ...)
+     (with-syntax ([(pict ...) (generate-temporaries #'(expr ...))])
+       (syntax/loc stx
+         (let ([pict expr] ...)
+           (combine (match test [pattern pict] ... [_ (blank 0 0)])
+                    (ghost pict) ...))))]
+    [(_ test [pattern expr] ...)
+     (quasisyntax/loc stx
+       (pict-match test #:combine #,(syntax-parameter-value #'pict-combine)
+                   [pattern expr] ...))]))
+
+(define (hide pict [hide? #t])
+  (if hide? (ghost pict) pict))
+
+(define (show pict [show? #t])
+  (if show? pict (ghost pict)))

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -13,7 +13,10 @@
              pict->argb-pixels
              argb-pixels->pict
              colorize
-             pin-under pin-over disk
+             pin-under pin-over
+             rectangle filled-rectangle
+             rounded-rectangle filled-rounded-rectangle
+             circle disk ellipse filled-ellipse
              vl-append
              vc-append
              vr-append
@@ -87,12 +90,64 @@
                    (-> pict? pict-path? (values real? real?)))]
          [pict pict?])
         [result pict?])]
-  [disk (->* ((and/c rational? (not/c negative?)))
-             (#:draw-border? any/c
-              #:color (or/c #f string? (is-a?/c color%))
-              #:border-color (or/c #f string? (is-a?/c color%))
-              #:border-width (or/c #f real?))
-             pict?)]))
+  [rectangle (->* ((and/c rational? (not/c negative?))
+                   (and/c rational? (not/c negative?)))
+                  (#:border-color (or/c #f string? (is-a?/c color%))
+                   #:border-width (or/c #f (and/c rational? (not/c negative?))))
+                  pict?)]
+  [filled-rectangle (->i ([w (and/c rational? (not/c negative?))]
+                          [h (and/c rational? (not/c negative?))])
+                         (#:draw-border? [draw-border? any/c]
+                          #:color        [color (or/c #f string? (is-a?/c color%))]
+                          #:border-color [border-color (or/c #f string? (is-a?/c color%))]
+                          #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
+                         #:pre (draw-border? border-color border-width)
+                         (if (not draw-border?) (not (or border-width border-color)) #t)
+                         [_ pict?])]
+  [rounded-rectangle (->* ((and/c rational? (not/c negative?))
+                           (and/c rational? (not/c negative?)))
+                          (rational?
+                           #:angle rational?
+                           #:border-color (or/c #f string? (is-a?/c color%))
+                           #:border-width (or/c #f (and/c rational? (not/c negative?))))
+                          pict?)]
+  [filled-rounded-rectangle (->i ([w (and/c rational? (not/c negative?))]
+                                  [h (and/c rational? (not/c negative?))])
+                                 ([corner-radius rational?]
+                                  #:angle        [angle rational?]
+                                  #:draw-border? [draw-border? any/c]
+                                  #:color        [color (or/c #f string? (is-a?/c color%))]
+                                  #:border-color [border-color (or/c #f string? (is-a?/c color%))]
+                                  #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
+                                 #:pre (draw-border? border-color border-width)
+                                 (if (not draw-border?) (not (or border-width border-color)) #t)
+                                 [_ pict?])]
+  [circle (->* ((and/c rational? (not/c negative?)))
+               (#:border-color (or/c #f string? (is-a?/c color%))
+                #:border-width (or/c #f (and/c rational? (not/c negative?))))
+               pict?)]
+  [disk (->i ([r (and/c rational? (not/c negative?))])
+             (#:draw-border? [draw-border? any/c]
+              #:color        [color (or/c #f string? (is-a?/c color%))]
+              #:border-color [border-color (or/c #f string? (is-a?/c color%))]
+              #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
+             #:pre (draw-border? border-color border-width)
+             (if (not draw-border?) (not (or border-width border-color)) #t)
+             [_ pict?])]
+  [ellipse (->* ((and/c rational? (not/c negative?))
+                 (and/c rational? (not/c negative?)))
+                (#:border-color (or/c #f string? (is-a?/c color%))
+                 #:border-width (or/c #f (and/c rational? (not/c negative?))))
+                pict?)]
+  [filled-ellipse (->i ([w (and/c rational? (not/c negative?))]
+                        [h (and/c rational? (not/c negative?))])
+                       (#:draw-border? [draw-border? any/c]
+                        #:color        [color (or/c #f string? (is-a?/c color%))]
+                        #:border-color [border-color (or/c #f string? (is-a?/c color%))]
+                        #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
+                       #:pre (draw-border? border-color border-width)
+                       (if (not draw-border?) (not (or border-width border-color)) #t)
+                       [_ pict?])]))
 
 (define (does-draw-restore-the-state-after-being-called? draw)
   (define bdc (new bitmap-dc% [bitmap (make-bitmap 1 1)]))

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -87,7 +87,12 @@
                    (-> pict? pict-path? (values real? real?)))]
          [pict pict?])
         [result pict?])]
-  [disk (->* ((and/c rational? (not/c negative?))) (#:draw-border? any/c) pict?)]))
+  [disk (->* ((and/c rational? (not/c negative?)))
+             (#:draw-border? any/c
+              #:color (or/c #f string? (is-a?/c color%))
+              #:border-color (or/c #f string? (is-a?/c color%))
+              #:border-width (or/c #f real?))
+             pict?)]))
 
 (define (does-draw-restore-the-state-after-being-called? draw)
   (define bdc (new bitmap-dc% [bitmap (make-bitmap 1 1)]))

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -102,7 +102,12 @@
                           #:border-color [border-color (or/c #f string? (is-a?/c color%))]
                           #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
                          #:pre (draw-border? border-color border-width)
-                         (if (not draw-border?) (not (or border-width border-color)) #t)
+                         (if (not draw-border?)
+                             (and (or (unsupplied-arg? border-color)
+                                      (not border-color))
+                                  (or (unsupplied-arg? border-width)
+                                      (not border-width)))
+                             #t)
                          [_ pict?])]
   [rounded-rectangle (->* ((and/c rational? (not/c negative?))
                            (and/c rational? (not/c negative?)))
@@ -120,7 +125,12 @@
                                   #:border-color [border-color (or/c #f string? (is-a?/c color%))]
                                   #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
                                  #:pre (draw-border? border-color border-width)
-                                 (if (not draw-border?) (not (or border-width border-color)) #t)
+                                 (if (not draw-border?)
+                                     (and (or (unsupplied-arg? border-color)
+                                              (not border-color))
+                                          (or (unsupplied-arg? border-width)
+                                              (not border-width)))
+                                     #t)
                                  [_ pict?])]
   [circle (->* ((and/c rational? (not/c negative?)))
                (#:border-color (or/c #f string? (is-a?/c color%))
@@ -132,7 +142,12 @@
               #:border-color [border-color (or/c #f string? (is-a?/c color%))]
               #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
              #:pre (draw-border? border-color border-width)
-             (if (not draw-border?) (not (or border-width border-color)) #t)
+             (if (not draw-border?)
+                 (and (or (unsupplied-arg? border-color)
+                          (not border-color))
+                      (or (unsupplied-arg? border-width)
+                          (not border-width)))
+                 #t)
              [_ pict?])]
   [ellipse (->* ((and/c rational? (not/c negative?))
                  (and/c rational? (not/c negative?)))
@@ -146,7 +161,12 @@
                         #:border-color [border-color (or/c #f string? (is-a?/c color%))]
                         #:border-width [border-width (or/c #f (and/c rational? (not/c negative?)))])
                        #:pre (draw-border? border-color border-width)
-                       (if (not draw-border?) (not (or border-width border-color)) #t)
+                       (if (not draw-border?)
+                           (and (or (unsupplied-arg? border-color)
+                                    (not border-color))
+                                (or (unsupplied-arg? border-width)
+                                    (not border-width)))
+                           #t)
                        [_ pict?])]))
 
 (define (does-draw-restore-the-state-after-being-called? draw)

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -283,7 +283,9 @@
             (define old-pen   (send dc get-pen))
             (send dc set-brush
                   (send the-brush-list find-or-create-brush
-                        (or color (send old-pen get-color))
+                        (cond [transparent? "white"]
+                              [color        color]
+                              [else         (send old-pen get-color)])
                         (if transparent? 'transparent 'solid)))
             (if draw-border?
                 (when (or border-color border-width)

--- a/pict-lib/pict/shadow.rkt
+++ b/pict-lib/pict/shadow.rkt
@@ -1,0 +1,401 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         racket/unsafe/ops
+         racket/contract/base
+         racket/class
+         racket/draw
+         racket/future
+         racket/math
+         pict)
+
+(define nneg-real/c (and/c real? (not/c negative?)))
+
+(provide/contract
+ [blur
+  (->* (pict? nneg-real/c)
+       (nneg-real/c
+        #:pre-inset? any/c)
+       pict?)]
+ [shadow
+  (->* (pict? nneg-real/c)
+       (real? real?
+        #:color (or/c #f string? (is-a?/c color%))
+        #:shadow-color (or/c #f string? (is-a?/c color%)))
+       pict?)]
+ [shadow-frame
+  (->* ()
+       (#:background-color (or/c string? (is-a?/c color%))
+        #:frame-color (or/c string? (is-a?/c color%))
+        #:frame-line-width (or/c real? #f)
+        #:shadow-side-length real?
+        #:shadow-top-y-offset real?
+        #:shadow-bottom-y-offset real?
+        #:shadow-descent (and/c real? (not/c negative?))
+        #:shadow-alpha-factor real?
+        #:blur (and/c real? (not/c negative?))
+        #:margin real?
+        #:sep real?)
+       #:rest (listof pict?)
+       pict?)])
+
+;; ----
+
+(define (blur p hbr [vbr hbr]
+              #:pre-inset? [pre-inset? #t])
+  (let* ([p
+          (cond [pre-inset? (inset p hbr vbr)]
+                [else p])]
+         [blurred (*blur p hbr vbr)])
+    (cond [pre-inset? (inset blurred (- hbr) (- vbr))]
+          [else blurred])))
+
+(define (shadow p br [dx 0] [dy dx]
+                #:color [c #f]
+                #:shadow-color [shc #f]
+                #:auto-inset? [auto-inset? #f])
+  ;; FIXME: should auto-inset also use dx, dy?
+  (define (colorize* p c)
+    (if c (colorize p c) p))
+  (let ([result
+         (pin-under (colorize* p c)
+                    dx dy
+                    (blur (colorize* p shc) br))])
+    (cond [auto-inset? (inset result br)]
+          [else result])))
+
+;; ----
+
+(define MAX-RADIUS (expt 2 10))
+(define MAX-WEIGHT (expt 2 5))
+(define BOX-ITERATIONS 3)
+
+(define (*blur p hbr vbr)
+  (let* ([w (pict-width p)]
+         [h (pict-height p)]
+         [drawer (make-pict-drawer p)])
+    (dc (lambda (dc x y)
+          (let-values ([(sx sy) (send dc get-scale)])
+            (let* ([pxw (ceil/e (* w sx))]
+                   [pxh (ceil/e (* h sy))]
+                   [hbr* (min (ceil/e (* hbr sx)) pxw MAX-RADIUS)]
+                   [vbr* (min (ceil/e (* vbr sy)) pxh MAX-RADIUS)]
+                   [bmp (make-object bitmap% pxw pxh #f #t)]
+                   [bdc (new bitmap-dc% (bitmap bmp))])
+              (send bdc set-scale sx sy)
+              (send bdc set-font (send dc get-font))
+              (send bdc set-pen (send dc get-pen))
+              (send bdc set-brush (send dc get-brush))
+              (send bdc set-text-foreground (send dc get-text-foreground))
+              (when (or (zero? hbr*) (zero? vbr*))
+                ;; probably not worth smoothing when about to blur
+                ;; except when blurring by zero
+                (send bdc set-smoothing (send dc get-smoothing)))
+              (drawer bdc 0 0)
+              (blur! bmp hbr* vbr*)
+              (send dc set-scale 1.0 1.0)
+              (send dc draw-bitmap bmp (* x sx) (* y sy))
+              (send dc set-scale sx sy))))
+        w h)))
+
+(define (blur! bmp hbr vbr)
+  (let* ([w (send bmp get-width)]
+         [h (send bmp get-height)]
+         [pix (make-bytes (* w h 4))]
+         [out (make-bytes (* w h 4))])
+    (send bmp get-argb-pixels 0 0 w h pix #f #t)
+    (let ([hbr (ceil/e (/ hbr BOX-ITERATIONS))]
+          [vbr (ceil/e (/ vbr BOX-ITERATIONS))])
+      (box-h pix out hbr w h BOX-ITERATIONS)
+      (let-values ([(pix* out*)
+                    (cond [(even? BOX-ITERATIONS) (values out pix)]
+                          [else (values pix out)])])
+        (box-v pix* out* vbr w h BOX-ITERATIONS)))
+    (send bmp set-argb-pixels 0 0 w h pix #f #t)
+    (void)))
+
+;; ----
+
+;; iterated box blur
+
+(define-syntax-rule (box-line* radius start end get-val set-val)
+  (let ([non-zero-alpha?
+         (for/or ([outi (in-range start end)])
+           (positive? (get-val outi 0)))])
+    (cond [non-zero-alpha?
+           (for/fold ([wA 0] [wR 0] [wG 0] [wB 0] [wW 0])
+             ([leadI (in-range start (+ end radius))])
+             ;; (eprintf "leadI = ~s, wA = ~s, wW = ~s\n" leadI wA wW)
+             (let*-values ([(outI) (unsafe-fx- leadI radius)]
+                           [(tailI) (unsafe-fx- leadI (unsafe-fx+ radius radius))]
+                           [(addA addR addG addB addW)
+                            (cond [(unsafe-fx< leadI end)
+                                   (values (get-val leadI 0)
+                                           (get-val leadI 1)
+                                           (get-val leadI 2)
+                                           (get-val leadI 3)
+                                           1)]
+                                  [else (values 0 0 0 0 0)])]
+                           [(dropA dropR dropG dropB dropW)
+                            (cond [(unsafe-fx>= tailI start)
+                                   (values (get-val tailI 0)
+                                           (get-val tailI 1)
+                                           (get-val tailI 2)
+                                           (get-val tailI 3)
+                                           1)]
+                                  [else (values 0 0 0 0 0)])]
+                           [(nwA) (unsafe-fx+ wA addA)]
+                           [(nwR) (unsafe-fx+ wR addR)]
+                           [(nwG) (unsafe-fx+ wG addG)]
+                           [(nwB) (unsafe-fx+ wB addB)]
+                           [(nwW) (unsafe-fx+ wW addW)])
+               (when (and (unsafe-fx>= outI start) (unsafe-fx< outI end))
+                 ;; (eprintf "setting ~a = (~a,...)\n" outI (quotient nwA nwW))
+                 (set-val outI 0 (unsafe-fxquotient nwA nwW))
+                 (set-val outI 1 (unsafe-fxquotient nwR nwW))
+                 (set-val outI 2 (unsafe-fxquotient nwG nwW))
+                 (set-val outI 3 (unsafe-fxquotient nwB nwW)))
+               (values (unsafe-fx- nwA dropA)
+                       (unsafe-fx- nwR dropR)
+                       (unsafe-fx- nwG dropG)
+                       (unsafe-fx- nwB dropB)
+                       (unsafe-fx- nwW dropW))))]
+          [else
+           (for ([outI (in-range start end)])
+             (set-val outI 0 0)
+             (set-val outI 1 0)
+             (set-val outI 2 0)
+             (set-val outI 3 0))])))
+
+(define (box-h in out radius w h iterations)
+  (for/async ([row (in-range h)])
+    (for ([iter (in-range iterations)])
+      (let ([start (* row w)]
+            [end (* (add1 row) w)]
+            [in (if (even? iter) in out)]
+            [out (if (even? iter) out in)])
+        (define-syntax-rule (get-val i offset)
+          (bytes-ref in (unsafe-fx+ offset (unsafe-fx* 4 i))))
+        (define-syntax-rule (set-val i offset v)
+          (bytes-set! out (unsafe-fx+ offset (unsafe-fx* 4 i)) v))
+        (box-line* radius start end get-val set-val)))))
+
+(define (box-v in out radius w h iterations)
+  (for/async ([col (in-range w)])
+    (for ([iter (in-range iterations)])
+      (let ([start 0]
+            [end h]
+            [in (if (even? iter) in out)]
+            [out (if (even? iter) out in)])
+        (define-syntax-rule (get-val i offset)
+          (bytes-ref in (unsafe-fx+ (unsafe-fx* 4 (unsafe-fx+ (unsafe-fx* w i) col)) offset)))
+        (define-syntax-rule (set-val i offset v)
+          (bytes-set! out (unsafe-fx+ (unsafe-fx* 4 (unsafe-fx+ (unsafe-fx* w i) col)) offset) v))
+        (box-line* radius start end get-val set-val)))))
+
+(define (ceil/e x) (inexact->exact (ceiling x)))
+
+;; ----
+
+;; used for benchmarking to force effectively lazy dc pict constructor
+(define (p->bmp p)
+  (let* ([bmp (make-object bitmap% (ceil/e (pict-width p)) (ceil/e (pict-height p)))]
+         [bdc (new bitmap-dc% (bitmap bmp))])
+    (draw-pict p bdc 0 0)
+    bmp))
+
+;; ============================================================
+;; Boxes with Keynote-style shadows
+
+(define (shadow-frame #:background-color [background-color "white"]
+                      #:frame-color [frame-color "gray"]
+                      #:frame-line-width [frame-line-width 0]
+                      #:shadow-side-length [s-side-len 4.0]
+                      #:shadow-top-y-offset [s-top-dy 10.0]
+                      #:shadow-bottom-y-offset [s-bot-dy 4.0]
+                      #:shadow-descent [s-desc 40.0]
+                      #:shadow-alpha-factor [s-alpha 3/4]
+                      #:blur [blur-radius 20]
+                      #:margin [margin-len 20]
+                      #:sep [sep 5]
+                      . picts)
+  ;; shadow-alpha-factor:
+  ;;   - default 3/4 good for a heavy shadow, if blur is enabled
+  ;;   - about 1/4 or 1/5 good for light shadow w/o blur
+  (let* ([pict (apply vl-append sep picts)]
+         [pict (inset pict margin-len)]
+         [w (pict-width pict)]
+         [h (pict-height pict)]
+         [main-box (frame (colorize (filled-rectangle w h) background-color)
+                          #:color frame-color #:line-width frame-line-width)]
+         [w* (+ w s-side-len s-side-len)]
+         [shadow (arch w* w* (+ h (- s-bot-dy s-top-dy)) s-desc)]
+         [shadow (brush/linear-gradient
+                  shadow
+                  (mk-shadow-grad-stops w* s-side-len s-alpha))]
+         [shadow
+          (cond [(zero? blur-radius) shadow]
+                [#t ;; use-smart-blur?
+                 (smart-blur shadow w h blur-radius
+                             s-side-len s-top-dy s-bot-dy s-desc)]
+                [else (blur shadow blur-radius)])]
+         [result
+          (pin-under (cc-superimpose main-box pict)
+                     (- s-side-len) s-top-dy
+                     shadow)]
+         [result
+          (inset result s-side-len 0
+                 s-side-len (+ s-desc (- s-top-dy s-bot-dy)))])
+    (inset result blur-radius)))
+
+;; smart-blur: blur only visible edges
+(define (smart-blur shadow w0 h0 blur-radius s-side-len s-top-dy s-bot-dy s-desc)
+  (define (blur-part p x1 y1 x2 y2 lpad tpad rpad bpad)
+    (let* ([p (viewport p (- x1 lpad) (- y1 tpad) (+ x2 rpad) (+ y2 bpad))]
+           [p (blur p blur-radius #:pre-inset? #f)]
+           [p (clip (inset p (- lpad) (- tpad) (- rpad) (- bpad)))])
+      p))
+  (define (viewport p x1 y1 x2 y2)
+    (clip (pin-over (blank (- x2 x1) (- y2 y1)) (- x1) (- y1) p)))
+  (let* ([shadow* (inset shadow blur-radius)]
+         [w* (pict-width shadow*)]
+         [h* (pict-height shadow*)]
+         [BR blur-radius]
+
+         [yTopBot (+ BR (- s-top-dy))]
+         [yMidBot (+ yTopBot h0)]
+         [xLeftRight (+ BR s-side-len)]
+
+         [top-part
+          (blur-part shadow*
+                     0 0 w* yTopBot
+                     0 0 0 BR)]
+         [left-part
+          (blur-part shadow*
+                     0 yTopBot xLeftRight yMidBot
+                     0 BR BR BR)]
+         [right-part
+          (blur-part shadow*
+                     (- w* xLeftRight) yTopBot w* yMidBot
+                     BR BR 0 BR)]
+         [bot-part
+          (blur-part shadow*
+                     0 yMidBot w* h*
+                     0 BR 0 0)]
+
+         [result (blank w* h*)]
+         [result (pin-over result 0 0 top-part)]
+         [result (pin-over result 0 yTopBot left-part)]
+         [result (pin-over result (- w* xLeftRight) yTopBot right-part)]
+         [result (pin-over result 0 yMidBot bot-part)])
+    (inset result (- blur-radius))))
+
+(define (mk-shadow-grad-stops w s-side-len s-alpha)
+  (let* ([epsA (/ s-side-len w)]
+         [epsZ (- 1.0 epsA)]
+         [alphaA (max 0 (min 1 (* s-alpha 0.16)))]
+         [alphaB (max 0 (min 1 (* s-alpha 0.25)))]
+         [alphaC (max 0 (min 1 (* s-alpha 1.00)))])
+    (list (list 0.00 (make-object color% 0 0 0 alphaA))
+          (list epsA (make-object color% 0 0 0 alphaB))
+          (list 0.25 (make-object color% 0 0 0 alphaC))
+          (list 0.75 (make-object color% 0 0 0 alphaC))
+          (list epsZ (make-object color% 0 0 0 alphaB))
+          (list 1.00 (make-object color% 0 0 0 alphaA)))))
+
+;; ----
+
+(define (arch outer-w inner-w solid-h leg-h)
+  (dc (lambda (dc X Y)
+        (draw-arch dc X Y outer-w inner-w solid-h leg-h))
+      outer-w (+ solid-h leg-h)))
+
+(define (draw-arch dc X Y outer-w inner-w solid-h leg-h)
+  (cond [(zero? leg-h)
+         (send dc draw-rectangle X Y outer-w solid-h)]
+        [else
+         (let ([path (new dc-path%)])
+           (dc-path-arch path X Y outer-w inner-w solid-h leg-h)
+           (send dc draw-path path))]))
+
+;; closes path's current sub-path and draws the outline of an arch, clockwise
+;; requires leg-h != 0
+(define (dc-path-arch path X Y outer-w inner-w solid-h leg-h)
+  (let* ([xA X]
+         [xB (+ X outer-w)]
+         [xMid (/ (+ xA xB) 2.0)]
+         [ySolidEnd (+ Y solid-h)]
+         [yEnd (+ Y solid-h leg-h)]
+         [hdx (/ (- outer-w inner-w) 2.0)]
+         [xAi (+ xA hdx)]
+         [xBi (- xB hdx)]
+         [radius (+ (/ leg-h 2) (/ (sqr inner-w) 8 leg-h))]
+         [diameter (+ radius radius)]
+         [theta (asin (/ (- radius leg-h) radius))])
+    (send* path
+      (move-to xA Y)
+      (line-to xB Y)
+      (line-to xB ySolidEnd)
+      (line-to xB yEnd)
+      (line-to xBi yEnd)
+      (arc (- xMid radius) ySolidEnd
+           diameter diameter
+           theta
+           (- pi theta))
+      ;; ends at *roughly* xAi yEnd
+      (line-to xAi yEnd)
+      (line-to xA yEnd)
+      (line-to xA ySolidEnd)
+      (line-to xA Y))))
+
+;; ====
+
+(define no-pen (make-object pen% "BLACK" 1 'transparent))
+
+(define (brush/linear-gradient p stops)
+  (let* ([drawer (make-pict-drawer p)]
+         [w (pict-width p)]
+         [h (pict-height p)])
+    (dc (lambda (dc X Y)
+          (let* ([grad
+                  (new linear-gradient%
+                       ;; Apparently gradient handles scaling,
+                       ;; rotation, etc automatically (???)
+                       (x0 X) (y0 Y) (x1 (+ X w)) (y1 Y)
+                       (stops stops))]
+                 [new-brush (new brush% (gradient grad))]
+                 [old-pen (send dc get-pen)]
+                 [old-brush (send dc get-brush)])
+            (send* dc
+              (set-pen no-pen)
+              (set-brush new-brush))
+            (drawer dc X Y)
+            (send* dc
+              (set-pen old-pen)
+              (set-brush old-brush))))
+        w h)))
+
+#|
+;; FIXME:
+;;   (arch ....) by itself draws outline
+;;   (colorize (arch ....) "red") draws filled (no outline, or same color)
+
+Problem: picts, colorize, etc not designed to inherit brush. See
+texpict/utils: filled-rectangle, eg, makes new brush from pen color;
+rectangle makes new transparent brush.
+
+|#
+
+;; ----
+
+;; provided by unstable/gui/pict, for backwards compatibility
+(module+ unstable
+  (provide/contract
+   [blur-bitmap!
+    (->* ((is-a?/c bitmap%) exact-nonnegative-integer?)
+         (exact-nonnegative-integer?)
+         void?)]
+   [arch
+    (-> real? real? real? real?
+        pict?)])
+  (define (blur-bitmap! bmp hbr [vbr hbr])
+    (blur! bmp hbr vbr)))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -22,9 +22,11 @@
      (send b get-argb-pixels 0 0 w h its #t))
   its)
 
-(define-check (check-pict=? actual expected msg)
+(define-check (check-pict=?/msg actual expected msg)
   (unless (equal? (->bitmap actual) (->bitmap expected))
     (fail-check msg)))
+(define-syntax-rule (check-pict=? actual expected)
+  (check-pict=?/msg actual expected ""))
 
 (define-syntax (gen-case stx)
   (syntax-parse stx
@@ -61,7 +63,7 @@
  "freeze random testing"
  (for ([i 1000])
    (define-values (l p) (generate-pict))
-   (check-pict=? p (freeze p) (format "~a" l))))
+   (check-pict=?/msg p (freeze p) (format "~a" l))))
 
 (test-case
  "scale-to-fit"

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -266,3 +266,18 @@
  (for ([i 1000])
    (define-values (old new trace) (generate-shapes 4))
    (check-pict=?/msg old new (format "~a" trace))))
+
+;; a few that caused issues with previous version of the new implementation
+(check-pict=? (ellipse 7 3) (old-ellipse 7 3))
+(check-pict=? (hc-append (hc-append (circle 3) (ellipse 0 0))
+                         (rectangle 0 9))
+              (hc-append (hc-append (old-circle 3) (old-ellipse 0 0))
+                         (old-rectangle 0 9)))
+(check-pict=? (rectangle 1 3) (old-rectangle 1 3))
+(check-pict=? (ht-append (ellipse 3 1)
+                         (hb-append (filled-rectangle 8 2 #:draw-border? #t)
+                                    (ellipse 5 0)))
+              (ht-append (old-ellipse 3 1)
+                         (hb-append (old-filled-rectangle 8 2 #:draw-border? #t)
+                                    (old-ellipse 5 0))))
+(check-pict=? (rectangle 0 3) (old-rectangle 0 3))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -62,3 +62,14 @@
  (for ([i 1000])
    (define-values (l p) (generate-pict))
    (check-pict=? p (freeze p) (format "~a" l))))
+
+(test-case
+ "scale-to-fit"
+ (define p (rectangle 10 20))
+ (check-pict=? (scale-to-fit p p) p)
+ (check-pict=? (scale-to-fit p (scale p 2)) (scale p 2))
+ (check-pict=? (scale-to-fit p 40 40) (scale p 2))
+ (check-pict=? (scale-to-fit p 40 40 #:mode 'inset)
+               (cc-superimpose (blank 40 40)
+                               (scale p 2)))
+ (check-pict=? (scale-to-fit p 40 40 #:mode 'distort) (scale p 4 2)))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require pict rackunit
-         (for-syntax syntax/parse))
+         (for-syntax syntax/parse)
+         racket/draw racket/class)
 
 (define (->bitmap p)
   (define b (pict->bitmap p))
@@ -75,3 +76,193 @@
                (cc-superimpose (blank 40 40)
                                (scale p 2)))
  (check-pict=? (scale-to-fit p 40 40 #:mode 'distort) (scale p 4 2)))
+
+
+;; check whether the new implementation of shapes (with borders and colors)
+;; are equivalent to the old ones (for the feature subset of the old one)
+
+(define (old-filled-rectangle w h #:draw-border? [draw-border? #t])
+  (dc
+   (lambda (dc x y)
+     (let ([b (send dc get-brush)]
+           [p (send dc get-pen)])
+       (send dc set-brush (send the-brush-list find-or-create-brush
+                                (send p get-color)
+                                'solid))
+       (unless draw-border?
+         (send dc set-pen "black" 1 'transparent))
+       (send dc draw-rectangle x y w h)
+       (send dc set-brush b)
+       (send dc set-pen p)))
+   w
+   h))
+
+(define (old-rectangle w h)
+  (dc
+   (lambda (dc x y)
+     (let ([b (send dc get-brush)])
+       (send dc set-brush (send the-brush-list find-or-create-brush
+                                "white" 'transparent))
+       (send dc draw-rectangle x y w h)
+       (send dc set-brush b)))
+   w
+   h))
+
+(define (old-rounded-rectangle w h [corner-radius -0.25] #:angle [angle 0])
+  (let ([dc-path (new dc-path%)])
+    (send dc-path rounded-rectangle 0 0 w h corner-radius)
+    (send dc-path rotate angle)
+    (let-values ([(x y w h) (send dc-path get-bounding-box)])
+      (dc (λ (dc dx dy)
+            (let ([brush (send dc get-brush)])
+              (send dc set-brush (send the-brush-list find-or-create-brush
+                                       "white" 'transparent))
+              (send dc draw-path dc-path (- dx x) (- dy y))
+              (send dc set-brush brush)))
+          w
+          h))))
+
+(define (old-filled-rounded-rectangle w h [corner-radius -0.25] #:angle [angle 0] #:draw-border? [draw-border? #t])
+  (let ([dc-path (new dc-path%)])
+    (send dc-path rounded-rectangle 0 0 w h corner-radius)
+    (send dc-path rotate angle)
+    (let-values ([(x y w h) (send dc-path get-bounding-box)])
+      (dc (λ (dc dx dy) 
+            (let ([brush (send dc get-brush)]
+                  [pen (send dc get-pen)])
+              (send dc set-brush (send the-brush-list find-or-create-brush
+                                       (send (send dc get-pen) get-color)
+                                       'solid))
+              (unless draw-border?
+                (send dc set-pen "black" 1 'transparent))
+              (send dc draw-path dc-path (- dx x) (- dy y))
+              (send dc set-brush brush)
+              (send dc set-pen pen)))
+          w
+          h))))
+
+(define (old-circle size) (ellipse size size))
+
+(define (old-ellipse width height)
+  (dc (lambda (dc x y)
+        (let ([b (send dc get-brush)])
+          (send dc set-brush (send the-brush-list find-or-create-brush
+                                   "white" 'transparent))
+          (send dc draw-ellipse x y width height)
+          (send dc set-brush b)))
+      width height))
+
+(define (old-disk size #:draw-border? [draw-border? #t])
+  (filled-ellipse size size #:draw-border? draw-border?))
+
+(define (old-filled-ellipse width height #:draw-border? [draw-border? #t])
+  (dc (lambda (dc x y)
+        (define b (send dc get-brush))
+        (define p (send dc get-pen))
+        (send dc set-brush (send the-brush-list find-or-create-brush
+                                 (send (send dc get-pen) get-color)
+                                 'solid))
+        (unless draw-border?
+          (send dc set-pen "black" 1 'transparent))
+        (send dc draw-ellipse x y width height)
+        (send dc set-brush b)
+        (send dc set-pen p))
+      width height))
+
+(define (random-boolean) (> (random) 0.5))
+(define (generate-shapes depth)
+  (define r (random (if (= depth 0) 8 15)))
+  (case r
+    [(0) (let ([w (random 10)]
+               [h (random 10)])
+           (values (old-rectangle w h)
+                   (rectangle w h)
+                   `(rectangle ,w ,h)))]
+    [(1) (let ([w (random 10)]
+               [h (random 10)]
+               [border? (random-boolean)])
+           (values (old-filled-rectangle w h #:draw-border? border?)
+                   (filled-rectangle w h #:draw-border? border?)
+                   `(filled-rectangle ,w ,h #:draw-border? ,border?)))]
+    [(2) (let ([w (random 10)]
+               [h (random 10)]
+               [corner (- (random) 0.5)]
+               [angle (* (- (random) 0.5) 2 pi)])
+           (values (old-rounded-rectangle w h corner #:angle angle)
+                   (rounded-rectangle w h corner #:angle angle)
+                   `(rounded-rectangle ,w ,h ,corner #:angle ,angle)))]
+    [(3) (let ([w (random 10)]
+               [h (random 10)]
+               [border? (random-boolean)]
+               [corner (- (random) 0.5)]
+               [angle (* (- (random) 0.5) 2 pi)])
+           (values (old-filled-rounded-rectangle w h corner
+                                                 #:angle angle
+                                                 #:draw-border? border?)
+                   (filled-rounded-rectangle w h corner
+                                             #:angle angle
+                                             #:draw-border? border?)
+                   `(filled-rounded-rectangle ,w ,h ,corner
+                                              #:angle ,angle
+                                              #:draw-border? ,border?)))]
+    [(4) (let ([r (random 10)])
+           (values (old-circle r)
+                   (circle r)
+                   `(circle ,r)))]
+    [(5) (let ([w (random 10)]
+               [h (random 10)])
+           (values (old-ellipse w h)
+                   (ellipse w h)
+                   `(ellipse ,w ,h)))]
+    [(6) (let ([r (random 10)]
+               [border? (random-boolean)])
+           (values (old-disk r #:draw-border? border?)
+                   (disk r #:draw-border? border?)
+                   `(disk ,r #:draw-border? ,border?)))]
+    [(7) (let ([w (random 10)]
+               [h (random 10)]
+               [border? (random-boolean)])
+           (values (old-filled-ellipse w h #:draw-border? border?)
+                   (filled-ellipse w h #:draw-border? border?)
+                   `(filled-ellipse ,w ,h #:draw-border? ,border?)))]
+    [(8) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                      [(old2 new2 t2) (generate-shapes (sub1 depth))])
+           (values (cc-superimpose old1 old2)
+                   (cc-superimpose new1 new2)
+                   `(cc-superimpose ,t1 ,t2)))]
+    [(9) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                      [(old2 new2 t2) (generate-shapes (sub1 depth))])
+           (values (ht-append old1 old2)
+                   (ht-append new1 new2)
+                   `(ht-append ,t1 ,t2)))]
+    [(10) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                       [(old2 new2 t2) (generate-shapes (sub1 depth))])
+            (values (hc-append old1 old2)
+                    (hc-append new1 new2)
+                    `(hc-append ,t1 ,t2)))]
+    [(11) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                       [(old2 new2 t2) (generate-shapes (sub1 depth))])
+            (values (hb-append old1 old2)
+                    (hb-append new1 new2)
+                    `(hb-append ,t1 ,t2)))]
+    [(12) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                       [(old2 new2 t2) (generate-shapes (sub1 depth))])
+            (values (vl-append old1 old2)
+                    (vl-append new1 new2)
+                    `(vl-append ,t1 ,t2)))]
+    [(13) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                       [(old2 new2 t2) (generate-shapes (sub1 depth))])
+            (values (vc-append old1 old2)
+                    (vc-append new1 new2)
+                    `(vc-append ,t1 ,t2)))]
+    [(14) (let-values ([(old1 new1 t1) (generate-shapes (sub1 depth))]
+                       [(old2 new2 t2) (generate-shapes (sub1 depth))])
+            (values (vr-append old1 old2)
+                    (vr-append new1 new2)
+                    `(vr-append t1 t2)))]))
+
+(test-case
+ "old and new shapes"
+ (for ([i 1000])
+   (define-values (old new trace) (generate-shapes 4))
+   (check-pict=?/msg old new (format "~a" trace))))


### PR DESCRIPTION
Introduces three new subcollects:
* `pict/color`, for color-related helpers
* `pict/conditional`, for conditional operators that combine picts
* `pict/shadow`, with shadow and blurring operations

In addition, extends some existing `pict` functions to cover use cases of functions in `unstable/gui/pict`:
* `scale-to-fit` gains a `#:mode` argument, which controls distortion (to cover the use cases of `scale-to`)
* shape constructors (e.g., `rectangle`) gain arguments to control background color, and border color and width (to cover the use cases of `rectangle/border`)
* `pin-line` and co gain arguments to add labels (to cover the use cases of `pin-label-line` and co)

The rest of `unstable/gui/pict` will stay there and leave the main distribution.

Code review would be very welcome, especially for the changes to the shape constructors, which are significant. I'm not familiar with the `pict` codebase, and it's not very well tested, so I'm sure I broke something.