### PR TITLE
Add contracts and adjust docs for use-last and use-last*

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -999,7 +999,7 @@ reported by @racket[pict-last]) set to @racket[sub-pict]. The
 @racket[sub-pict] must exist as a sub-pict (or path of sub-picts)
 within @racket[pict].}
 
-@defproc[(use-last* [pict pict?] [sub-pict pict-path?]) pict?]{
+@defproc[(use-last* [pict pict?] [sub-pict pict?]) pict?]{
 
 Propagates the last element of @racket[sub-pict] to @racket[pict].
 

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -9,6 +9,8 @@
 
 (provide 
  (except-out (all-from-out "private/main.rkt")
+             use-last
+             use-last*
              pict->bitmap
              pict->argb-pixels
              argb-pixels->pict
@@ -56,6 +58,9 @@
   [hb-append *-append/c]
   [htl-append *-append/c]
   [hbl-append *-append/c]
+
+  [use-last (-> pict? pict-path? pict?)]
+  [use-last* (-> pict? pict? pict?)]
   
   [colorize (-> pict? 
                 (or/c string? 


### PR DESCRIPTION
use-last* currently does not work when given pict-paths, and its not
clear how it should behave if given a pict-path. So, the new docs
and contract prohibit use-last* from taking a pict-path