### PR TITLE
Auto convert pict-convertibles to picts

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -304,7 +304,7 @@ Straight lines, centered within their @tech{bounding box}es.
 ]}
 
 
-@defproc[(frame [pict pict?]
+@defproc[(frame [pict pict-convertible?]
                 [#:segment seg-length (or/c #f real?) #f]
                 [#:color color (or/c #f string? (is-a?/c color<%>)) #f]
                 [#:line-width width (or/c #f real?) #f])
@@ -482,11 +482,11 @@ The @racket[size] is used for the arrowhead size. Even though
 @racket[pip-line] creates no arrowheads, it accepts the @racket[size]
 argument for consistency with the other functions.}
 
-@defproc*[([(pin-line [pict pict?]
+@defproc*[([(pin-line [pict pict-convertible?]
                       [src pict-path?]
-                      [find-src (pict? pict-path? . -> . (values real? real?))]
+                      [find-src (pict-convertible? pict-path? . -> . (values real? real?))]
                       [dest pict-path?]
-                      [find-dest (pict? pict-path? . -> . (values real? real?))]
+                      [find-dest (pict-convertible? pict-path? . -> . (values real? real?))]
                       [#:start-angle start-angle (or/c real? #f) #f]
                       [#:end-angle end-angle (or/c real? #f) #f]
                       [#:start-pull start-pull real? 1/4]
@@ -504,11 +504,11 @@ argument for consistency with the other functions.}
                       [#:x-adjust-label x-adjust-label real? 0]
                       [#:y-adjust-label y-adjust-label real? 0])
             pict?]
-           [(pin-arrow-line [arrow-size real?] [pict pict?]
+           [(pin-arrow-line [arrow-size real?] [pict pict-convertible?]
                       [src pict-path?]
-                      [find-src (pict? pict-path? . -> . (values real? real?))]
+                      [find-src (pict-convertible? pict-path? . -> . (values real? real?))]
                       [dest pict-path?]
-                      [find-dest (pict? pict-path? . -> . (values real? real?))]
+                      [find-dest (pict-convertible? pict-path? . -> . (values real? real?))]
                       [#:start-angle start-angle (or/c real? #f) #f]
                       [#:end-angle end-angle (or/c real? #f) #f]
                       [#:start-pull start-pull real? 1/4]
@@ -528,11 +528,11 @@ argument for consistency with the other functions.}
                       [#:solid? solid? any/c #t]
 		      [#:hide-arrowhead? hide-arrowhead? any/c #f])
             pict?]
-           [(pin-arrows-line [arrow-size real?] [pict pict?]
+           [(pin-arrows-line [arrow-size real?] [pict pict-convertible?]
                       [src pict-path?]
-                      [find-src (pict? pict-path? . -> . (values real? real?))]
+                      [find-src (pict-convertible? pict-path? . -> . (values real? real?))]
                       [dest pict-path?]
-                      [find-dest (pict? pict-path? . -> . (values real? real?))]
+                      [find-dest (pict-convertible? pict-path? . -> . (values real? real?))]
                       [#:start-angle start-angle (or/c real? #f) #f]
                       [#:end-angle end-angle (or/c real? #f) #f]
                       [#:start-pull start-pull real? 1/4]
@@ -545,7 +545,7 @@ argument for consistency with the other functions.}
                                                'xor-dot 'xor-long-dash 'xor-short-dash 
                                                'xor-dot-dash)]
                       [#:under? under? any/c #f]
-                      [#:label label pict? (blank)]
+                      [#:label label pict-convertible? (blank)]
                       [#:x-adjust-label x-adjust-label real? 0]
                       [#:y-adjust-label y-adjust-label real? 0]
                       [#:solid? solid? any/c #t]
@@ -628,14 +628,14 @@ bitmap.}
 
 @section{Pict Combiners}
 
-@defproc*[([(vl-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(vc-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(vr-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(ht-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(htl-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(hc-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(hbl-append [d real? 0.0] [pict pict?] ...) pict?]
-           [(hb-append [d real? 0.0] [pict pict?] ...) pict?])]{
+@defproc*[([(vl-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(vc-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(vr-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(ht-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(htl-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(hc-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(hbl-append [d real? 0.0] [pict pict-convertible?] ...) pict?]
+           [(hb-append [d real? 0.0] [pict pict-convertible?] ...) pict?])]{
 
 Creates a new pict as a column (for @racket[v...-append]) or row (for
 @racket[h...-append]) of other picts. The optional @racket[d] argument
@@ -671,21 +671,21 @@ supplied @racket[pict].
   (drop picts 4)
 ]}
 
-@defproc*[([(lt-superimpose [pict pict?] ...) pict?]
-           [(ltl-superimpose [pict pict?] ...) pict?]
-           [(lc-superimpose [pict pict?] ...) pict?]
-           [(lbl-superimpose [pict pict?] ...) pict?]
-           [(lb-superimpose [pict pict?] ...) pict?]
-           [(ct-superimpose [pict pict?] ...) pict?]
-           [(ctl-superimpose [pict pict?] ...) pict?]
-           [(cc-superimpose [pict pict?] ...) pict?]
-           [(cbl-superimpose [pict pict?] ...) pict?]
-           [(cb-superimpose [pict pict?] ...) pict?]
-           [(rt-superimpose [pict pict?] ...) pict?]
-           [(rtl-superimpose [pict pict?] ...) pict?]
-           [(rc-superimpose [pict pict?] ...) pict?]
-           [(rbl-superimpose [pict pict?] ...) pict?]
-           [(rb-superimpose [pict pict?] ...) pict?])]{
+@defproc*[([(lt-superimpose [pict pict-convertible?] ...) pict?]
+           [(ltl-superimpose [pict pict-convertible?] ...) pict?]
+           [(lc-superimpose [pict pict-convertible?] ...) pict?]
+           [(lbl-superimpose [pict pict-convertible?] ...) pict?]
+           [(lb-superimpose [pict pict-convertible?] ...) pict?]
+           [(ct-superimpose [pict pict-convertible?] ...) pict?]
+           [(ctl-superimpose [pict pict-convertible?] ...) pict?]
+           [(cc-superimpose [pict pict-convertible?] ...) pict?]
+           [(cbl-superimpose [pict pict-convertible?] ...) pict?]
+           [(cb-superimpose [pict pict-convertible?] ...) pict?]
+           [(rt-superimpose [pict pict-convertible?] ...) pict?]
+           [(rtl-superimpose [pict pict-convertible?] ...) pict?]
+           [(rc-superimpose [pict pict-convertible?] ...) pict?]
+           [(rbl-superimpose [pict pict-convertible?] ...) pict?]
+           [(rb-superimpose [pict pict-convertible?] ...) pict?])]{
 
 Creates a new picture by superimposing a set of pictures. The name
 prefixes are alignment indicators: horizontal alignment then vertical
@@ -724,12 +724,12 @@ comparing the last-element bottom-right corners.
 ]}
 
 
-@defproc*[([(pin-over [base pict?] [dx real?] [dy real?] [pict pict?])
+@defproc*[([(pin-over [base pict-convertible?] [dx real?] [dy real?] [pict pict-convertible?])
             pict?]
-           [(pin-over [base pict?]
+           [(pin-over [base pict-convertible?]
                       [find-pict pict-path?]
-                      [find (pict? pict-path? . -> . (values real? real?))]
-                      [pict pict?])
+                      [find (pict-convertible? pict-path? . -> . (values real? real?))]
+                      [pict pict-convertible?])
             pict?])]{
 
 Creates a pict with the same @tech{bounding box}, ascent, and descent as
@@ -741,12 +741,12 @@ pict's corner is from the first pict's corner.  Alternately, the
 should be something like @racket[lt-find].}
 
 
-@defproc*[([(pin-under [base pict?] [dx real?] [dy real?] [pict pict?])
+@defproc*[([(pin-under [base pict-convertible?] [dx real?] [dy real?] [pict pict-convertible?])
             pict?]
-           [(pin-under [base pict?] 
-                       [find-pict pict?]
-                       [find (pict? pict? . -> . (values real? real?))]
-                       [pict pict?])
+           [(pin-under [base pict-convertible?] 
+                       [find-pict pict-convertible?]
+                       [find (pict-convertible? pict-path? . -> . (values real? real?))]
+                       [pict pict-convertible?])
             pict?])]{
 
 Like @racket[pin-over], but @racket[pict] is drawn before
@@ -754,11 +754,11 @@ Like @racket[pin-over], but @racket[pict] is drawn before
 
 
 @defproc[(table [ncols exact-positive-integer?]
-                [picts (non-empty-listof pict?)]
-                [col-aligns (or/c (list*of (->* () #:rest (listof pict?) pict?))
-                                  (listof (->* () #:rest (listof pict?) pict?)))]
-                [row-aligns (or/c (list*of (->* () #:rest (listof pict?) pict?))
-                                  (listof (->* () #:rest (listof pict?) pict?)))]
+                [picts (non-empty-listof pict-convertible?)]
+                [col-aligns (or/c (list*of (->* () #:rest (listof pict-convertible?) pict-convertible?))
+                                  (listof (->* () #:rest (listof pict-convertible?) pict-convertible?)))]
+                [row-aligns (or/c (list*of (->* () #:rest (listof pict-convertible?) pict-convertible?))
+                                  (listof (->* () #:rest (listof pict-convertible?) pict-convertible?)))]
                 [col-seps (or/c (list*of real?) (listof real?))]
                 [row-seps (or/c (list*of real?) (listof real?))])
          pict?]{
@@ -809,8 +809,8 @@ horizontal or vertical placement of each cell in the column or row.
 
 @section{Pict Drawing Adjusters}
 
-@defproc*[([(scale [pict pict?] [factor real?]) pict?]
-           [(scale [pict pict?] [w-factor real?] [h-factor real?]) pict?])]{
+@defproc*[([(scale [pict pict-convertible?] [factor real?]) pict?]
+           [(scale [pict pict-convertible?] [w-factor real?] [h-factor real?]) pict?])]{
 
 Scales a pict drawing, as well as its @tech{bounding box}, by multiplying
 it current size by @racket[factor] (if two arguments are supplied)
@@ -828,10 +828,10 @@ scale while drawing the original @racket[pict].
 
 }
 
-@defproc*[([(scale-to-fit [pict pict?] [size-pict pict?]
+@defproc*[([(scale-to-fit [pict pict-convertible?] [size-pict pict-convertible?]
                           [#:mode mode (or/c 'preserve 'inset 'distort) 'preserve])
                           pict?]
-           [(scale-to-fit [pict pict?] [width real?] [height real?]
+           [(scale-to-fit [pict pict-convertible?] [width real?] [height real?]
                           [#:mode mode (or/c 'preserve 'inset 'distort) 'preserve])
                           pict?])]{
   Scales @racket[pict] so that it fits within the bounding box of
@@ -853,7 +853,7 @@ scale while drawing the original @racket[pict].
 }
 
 
-@defproc[(rotate [pict pict?] [theta real?]) pict?]{
+@defproc[(rotate [pict pict-convertible?] [theta real?]) pict?]{
 
 Rotates a pict's drawing by @racket[theta] radians counter-clockwise.
 
@@ -865,13 +865,13 @@ horizontal lines that bisect the rotated original lines; if the ascent
 line drops below the descent line, the two lines are flipped.}
 
 
-@defproc[(ghost [pict pict?]) pict?]{
+@defproc[(ghost [pict pict-convertible?]) pict?]{
 
 Creates a container picture that doesn't draw the child picture,
 but uses the child's size.}
 
 
-@defproc[(linewidth [w (or/c real? #f)] [pict pict?]) pict?]{
+@defproc[(linewidth [w (or/c real? #f)] [pict pict-convertible?]) pict?]{
 
 Selects a specific pen width for drawing, which applies to pen drawing
 for @racket[pict] that does not already use a specific pen width.
@@ -883,14 +883,14 @@ to a zero value, which means ``as thin as possible for the target device'').}
                                      'dot 'long-dash 'short-dash 'dot-dash 
                                      'xor-dot 'xor-long-dash 'xor-short-dash 
                                      'xor-dot-dash)]
-                    [pict pict?])
+                    [pict pict-convertible?])
          pict?]{
 
 Selects a specific pen style for drawing, which applies to pen drawing
 for @racket[pict] that does not already use a specific pen style.}
 
 
-@defproc[(colorize [pict pict?]
+@defproc[(colorize [pict pict-convertible?]
                    [color (or/c string? (is-a?/c color%)
                                 (list/c byte? byte? byte?))])
          pict?]{
@@ -900,7 +900,7 @@ Selects a specific color drawing, which applies to drawing in
 @racket[black-and-white] parameter causes all non-white colors to be
 converted to black.}
 
-@defproc[(cellophane [pict pict?] [opacity (real-in 0 1)])
+@defproc[(cellophane [pict pict-convertible?] [opacity (real-in 0 1)])
          pict?]{
 
 Makes the given @racket[pict] semi-transparent, where an opacity of
@@ -908,14 +908,14 @@ Makes the given @racket[pict] semi-transparent, where an opacity of
 opaque.  See @method[dc<%> set-alpha] for information about the
 contexts and cases when semi-transparent drawing works.}
 
-@defproc[(clip [pict pict?]) pict]{
+@defproc[(clip [pict pict-convertible?]) pict]{
 
 Clips a pict's drawing to its @tech{bounding box}.}
 
 
-@defproc*[([(inset/clip [pict pict?] [amt real?]) pict?]
-           [(inset/clip [pict pict?] [h-amt real?] [v-amt real?]) pict?]
-           [(inset/clip [pict pict?] [l-amt real?] [t-amt real?] 
+@defproc*[([(inset/clip [pict pict-convertible?] [amt real?]) pict?]
+           [(inset/clip [pict pict-convertible?] [h-amt real?] [v-amt real?]) pict?]
+           [(inset/clip [pict pict-convertible?] [l-amt real?] [t-amt real?] 
                         [r-amt real?] [b-amt real?]) pict?])]{
 
 Insets and clips the pict's drawing to its @tech{bounding
@@ -933,7 +933,7 @@ Like the @racket[scale] procedure, but also sets
 A parameter that determines whether @racket[colorize] uses color or
 black-and-white colors.}
 
-@defproc[(freeze [pict pict?]) pict?]{
+@defproc[(freeze [pict pict-convertible?]) pict?]{
  Creates a bitmap with the same size as @racket[pict], draws
  @racket[pict] into the bitmap, and then returns a pict that
  draws with the bitmap.
@@ -949,35 +949,35 @@ black-and-white colors.}
 
 @section{Bounding Box Adjusters}
 
-@defproc*[([(inset [pict pict?] [amt real?]) pict?]
-           [(inset [pict pict?] [h-amt real?] [v-amt real?]) pict?]
-           [(inset [pict pict?] [l-amt real?] [t-amt real?] 
+@defproc*[([(inset [pict pict-convertible?] [amt real?]) pict?]
+           [(inset [pict pict-convertible?] [h-amt real?] [v-amt real?]) pict?]
+           [(inset [pict pict-convertible?] [l-amt real?] [t-amt real?] 
                    [r-amt real?] [b-amt real?]) pict?])]{
 
 Extends @racket[pict]'s @tech{bounding box} by adding the given amounts
 to the corresponding sides; ascent and descent are extended, too.}
 
 
-@defproc[(clip-descent [pict pict?]) pict?]{
+@defproc[(clip-descent [pict pict-convertible?]) pict?]{
 
 Truncates @racket[pict]'s @tech{bounding box} by removing the descent part.}
 
 
-@defproc[(lift-above-baseline [pict pict?] [amt real?]) pict?]{
+@defproc[(lift-above-baseline [pict pict-convertible?] [amt real?]) pict?]{
 
 Lifts @racket[pict] relative to its baseline, extending the
 @tech{bounding box} height if necessary.}
 
-@defproc[(drop-below-ascent [pict pict?] [amt real?]) pict?]{
+@defproc[(drop-below-ascent [pict pict-convertible?] [amt real?]) pict?]{
 
 Drops @racket[pict] relative to its ascent line, extending the
 @tech{bounding box} height if necessary.}
 
-@defproc[(baseless [pict pict?]) pict?]{
+@defproc[(baseless [pict pict-convertible?]) pict?]{
 
 Makes the descent @racket[0] and the ascent the same as the height.}
 
-@defproc[(refocus [pict pict?] [sub-pict pict?]) pict?]{
+@defproc[(refocus [pict pict-convertible?] [sub-pict pict-convertible?]) pict?]{
 
 Assuming that @racket[sub-pict] can be found within @racket[pict],
 shifts the overall bounding box to that of @racket[sub-pict] (but
@@ -986,20 +986,20 @@ reported by @racket[pict-last] is also set to @racket[(or (pict-last
 sub-pict) sub-pict)].}
 
 
-@defproc[(panorama [pict pict?]) pict?]{
+@defproc[(panorama [pict pict-convertible?]) pict?]{
 
 Shifts the given pict's @tech{bounding box} to enclose the bounding boxes of
 all sub-picts (even @racket[launder]ed picts).}
 
 
-@defproc[(use-last [pict pict?] [sub-pict pict-path?]) pict?]{
+@defproc[(use-last [pict pict-convertible?] [sub-pict pict-path?]) pict?]{
 
 Returns a pict like @racket[pict], but with the last element (as
 reported by @racket[pict-last]) set to @racket[sub-pict]. The
 @racket[sub-pict] must exist as a sub-pict (or path of sub-picts)
 within @racket[pict].}
 
-@defproc[(use-last* [pict pict?] [sub-pict pict?]) pict?]{
+@defproc[(use-last* [pict pict-convertible?] [sub-pict pict-convertible?]) pict?]{
 
 Propagates the last element of @racket[sub-pict] to @racket[pict].
 
@@ -1013,21 +1013,21 @@ element of @racket[sub-pict] is used as the new last element for
 
 @section{Pict Finders}
 
-@defproc*[([(lt-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(ltl-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(lc-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(lbl-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(lb-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(ct-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(ctl-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(cc-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(cbl-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(cb-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(rt-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(rtl-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(rc-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(rbl-find [pict pict?] [find pict-path?]) (values real? real?)]
-           [(rb-find [pict pict?] [find pict-path?]) (values real? real?)])]{
+@defproc*[([(lt-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(ltl-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(lc-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(lbl-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(lb-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(ct-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(ctl-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(cc-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(cbl-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(cb-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(rt-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(rtl-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(rc-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(rbl-find [pict pict-convertible?] [find pict-path?]) (values real? real?)]
+           [(rb-find [pict pict-convertible?] [find pict-path?]) (values real? real?)])]{
 
 Locates a pict designated by @racket[find] is within @racket[pict]. If
 @racket[find] is a pict, then the @racket[pict] must have been created
@@ -1039,11 +1039,11 @@ be within the second element, and so on.}
 
 @defproc[(pict-path? [v any/c]) boolean?]{
 
-Returns @racket[#t] if @racket[v] is a @racket[pict] or a non-empty
-list of @racket[pict]s.}
+Returns @racket[#t] if @racket[v] is a @racket[pict-convertible?] or a non-empty
+list of @racket[pict-convertible?]s.}
 
 
-@defproc[(launder [pict pict?]) pict?]{
+@defproc[(launder [pict pict-convertible?]) pict?]{
 
 Creates a pict that has the same drawing and @tech{bounding box} of
 @racket[pict], but which hides all of its sub-picts so that they
@@ -1079,7 +1079,7 @@ pict with the same shape and location.}
 
 @section{Miscellaneous}
 
-@defproc[(hyperlinkize [pict pict?])
+@defproc[(hyperlinkize [pict pict-convertible?])
          pict?]{
 
 Adds an underline and blue color. The @racket[pict]'s height and
@@ -1142,7 +1142,7 @@ a small amount of drawing outside the pict's @tech{bounding box}.
 @history[#:added "1.2"]}
 
 
-@defproc[(draw-pict [pict pict?]
+@defproc[(draw-pict [pict pict-convertible?]
                     [dc (is-a?/c dc<%>)]
                     [x real?]
                     [y real?])
@@ -1152,7 +1152,7 @@ Draws @racket[pict] to @racket[dc], with its top-left corner at offset
  (@racket[x], @racket[y]).}
 
 
-@defproc[(pict->bitmap [pict pict?] 
+@defproc[(pict->bitmap [pict pict-convertible?] 
                        [smoothing (or/c 'unsmoothed 'smoothed 'aligned) 'aligned])
          (is-a?/c bitmap%)]{
 
@@ -1163,7 +1163,7 @@ When drawing the pict into the bitmap using the smoothing mode @racket[smoothing
 (see @method[set-smoothing dc<%>] for more information on smoothing modes).
 }
 
-@defproc[(pict->argb-pixels [pict pict?]
+@defproc[(pict->argb-pixels [pict pict-convertible?]
                             [smoothing (or/c 'unsmoothed 'smoothed 'aligned) 'aligned])
          bytes?]{
 Returns the @racket[bytes?] with the pixels corresponding the bitmap that @racket[pict->bitmap]
@@ -1199,7 +1199,7 @@ returns. Each pixel has four bytes in the result: the alpha, red, green, and blu
 @history[#:added "1.1"]
 }
 
-@defproc[(make-pict-drawer [pict pict?])
+@defproc[(make-pict-drawer [pict pict-convertible?])
          ((is-a?/c dc<%>) real? real? . -> . void?)]{
 
 Generates a pict-drawer procedure for multiple renderings of
@@ -1207,7 +1207,7 @@ Generates a pict-drawer procedure for multiple renderings of
 repeated calls to @racket[draw-pict].}
 
 
-@defproc[(show-pict [pict pict?]
+@defproc[(show-pict [pict pict-convertible?]
                     [w (or/c #f exact-nonnegative-integer?) #f] 
                     [h (or/c #f exact-nonnegative-integer?) #f] 
                     [#:frame-x frame-x (or/c (integer-in -10000 10000) #f)] 
@@ -1268,7 +1268,7 @@ to picts, but others are not).
 @defproc[(pict-convertible? [v any/c]) boolean?]{
 Returns @racket[#t] if @racket[v] supports the conversion protocol
 (by being a struct with the @racket[prop:pict-convertible] property)
-and @racket[#f] otherwise.
+and @racket[#f] otherwise. This function returns true for @racket[pict]s.
 }
 
 @defproc[(pict-convert [v pict-convertible?]) pict?]{

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -1238,7 +1238,9 @@ form sets this parameter while also scaling the resulting pict.}
 @racketmodname[pict/convert] library defines a protocol for
 values to convert themselves to @tech{picts}. The protocol
 is used by DrRacket's interactions window, for example, to render
-values that it prints.}
+values that it prints. Anything that is @racket[pict-convertible?]
+can be used wherever a @racket[pict] can be used. These values will
+be automatically converted to a pict when needed.}
 
 @defthing[prop:pict-convertible struct-type-property?]{
 
@@ -1271,6 +1273,27 @@ and @racket[#f] otherwise.
 
 @defproc[(pict-convert [v pict-convertible?]) pict?]{
   Requests a data conversion from @racket[v] to a pict.
+}
+
+@defthing[prop:pict-post-equality struct-type-property?]{
+This property allows a @racket[pict-convertible?] to determine how
+it is compared to a @racket[pict] for the purpose of functions like
+@racket[lt-find]. If this property is not provided then the original
+structure is saved and checked for @racket[eq?]ness with the
+@racket[pict-convertible?].
+
+A property whose value should be a procedure matching the contract
+@racket[(-> pict-post-equality? any/c boolean?)]. The first value
+will the value from which the property was read.
+}
+
+@defproc[(pict-post-equality? [v any/c]) boolean?]{
+Determines if @racket[v] has the @racket[prop:pict-post-equality] property.
+}
+
+@defproc[(post-pict=? [a any/c] [b any/c]) boolean?]{
+Checks if two values are @racket[eq?], or if they are equal via
+the procedure in a @racket[prop:pict-post-equality] property on either value.
 }
 
 @(close-eval ss-eval)

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -1275,25 +1275,4 @@ and @racket[#f] otherwise.
   Requests a data conversion from @racket[v] to a pict.
 }
 
-@defthing[prop:pict-post-equality struct-type-property?]{
-This property allows a @racket[pict-convertible?] to determine how
-it is compared to a @racket[pict] for the purpose of functions like
-@racket[lt-find]. If this property is not provided then the original
-structure is saved and checked for @racket[eq?]ness with the
-@racket[pict-convertible?].
-
-A property whose value should be a procedure matching the contract
-@racket[(-> pict-post-equality? any/c boolean?)]. The first value
-will the value from which the property was read.
-}
-
-@defproc[(pict-post-equality? [v any/c]) boolean?]{
-Determines if @racket[v] has the @racket[prop:pict-post-equality] property.
-}
-
-@defproc[(post-pict=? [a any/c] [b any/c]) boolean?]{
-Checks if two values are @racket[eq?], or if they are equal via
-the procedure in a @racket[prop:pict-post-equality] property on either value.
-}
-
 @(close-eval ss-eval)

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -1268,7 +1268,7 @@ to picts, but others are not).
 @defproc[(pict-convertible? [v any/c]) boolean?]{
 Returns @racket[#t] if @racket[v] supports the conversion protocol
 (by being a struct with the @racket[prop:pict-convertible] property)
-and @racket[#f] otherwise. This function returns true for @racket[pict]s.
+and @racket[#f] otherwise. This function returns @racket[true] for @racket[pict?]s.
 }
 
 @defproc[(pict-convert [v pict-convertible?]) pict?]{

--- a/pict-lib/pict/code.rkt
+++ b/pict-lib/pict/code.rkt
@@ -10,6 +10,7 @@
          racket/string
          syntax-color/lexer-contract
          syntax-color/racket-lexer
+         "convert.rkt"
          (for-syntax racket/base
                      syntax/to-string
                      mzlib/list))
@@ -58,7 +59,7 @@
   [current-const-color (parameter/c (or/c string? (is-a?/c color%)))]
   [current-base-color (parameter/c (or/c string? (is-a?/c color%)))]
   [current-reader-forms (parameter/c (listof symbol?))]
-  [code-align (-> pict? pict?)]
+  [code-align (-> pict-convertible? pict?)]
   [current-keyword-list (parameter/c (listof string?))]
   [current-const-list (parameter/c (listof string?))]
   [current-literal-list (parameter/c (listof string?))]

--- a/pict-lib/pict/color.rkt
+++ b/pict-lib/pict/color.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require racket/class racket/contract racket/draw
+         "convert.rkt"
          pict)
 
 (define color/c
@@ -11,18 +12,18 @@
 
 (provide/contract
  [color/c flat-contract?]
- [red     (-> pict? pict?)]
- [orange  (-> pict? pict?)]
- [yellow  (-> pict? pict?)]
- [green   (-> pict? pict?)]
- [blue    (-> pict? pict?)]
- [purple  (-> pict? pict?)]
- [black   (-> pict? pict?)]
- [brown   (-> pict? pict?)]
- [gray    (-> pict? pict?)]
- [white   (-> pict? pict?)]
- [cyan    (-> pict? pict?)]
- [magenta (-> pict? pict?)]
+ [red     (-> pict-convertible? pict?)]
+ [orange  (-> pict-convertible? pict?)]
+ [yellow  (-> pict-convertible? pict?)]
+ [green   (-> pict-convertible? pict?)]
+ [blue    (-> pict-convertible? pict?)]
+ [purple  (-> pict-convertible? pict?)]
+ [black   (-> pict-convertible? pict?)]
+ [brown   (-> pict-convertible? pict?)]
+ [gray    (-> pict-convertible? pict?)]
+ [white   (-> pict-convertible? pict?)]
+ [cyan    (-> pict-convertible? pict?)]
+ [magenta (-> pict-convertible? pict?)]
  [light (-> color/c color/c)]
  [dark (-> color/c color/c)])
 

--- a/pict-lib/pict/conditional.rkt
+++ b/pict-lib/pict/conditional.rkt
@@ -7,7 +7,7 @@
          (for-syntax racket/base))
 
 (provide/contract
- [hide (->* [pict-convertible?] [any/c] pict-convertible?)]
+ [hide (->* [pict-convertible?] [any/c] pict?)]
  [show (->* [pict-convertible?] [any/c] pict-convertible?)])
 (provide pict-if pict-cond pict-case)
 

--- a/pict-lib/pict/conditional.rkt
+++ b/pict-lib/pict/conditional.rkt
@@ -3,11 +3,12 @@
 (require pict
          racket/contract/base
          racket/stxparam
+         "convert.rkt"
          (for-syntax racket/base))
 
 (provide/contract
- [hide (->* [pict?] [any/c] pict?)]
- [show (->* [pict?] [any/c] pict?)])
+ [hide (->* [pict-convertible?] [any/c] pict-convertible?)]
+ [show (->* [pict-convertible?] [any/c] pict-convertible?)])
 (provide pict-if pict-cond pict-case)
 
 ;; The original API in unstable/gui/pict provided a syntax parameter to control

--- a/pict-lib/pict/convert.rkt
+++ b/pict-lib/pict/convert.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
-(require "main.rkt"
+(require "private/pict.rkt"
          racket/contract/base
          "private/convertible.rkt")
 

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -38,22 +38,6 @@
  pin-arrows-line
  pin-line
  (contract-out
-  #;
-  [pin-line
-   (->* (pict? pict-path? find/c pict-path? find/c)
-        (#:start-angle (or/c real? #f)
-         #:end-angle (or/c real? #f)
-         #:start-pull start-pull
-         #:end-pull end-pull
-         #:line-width line-width
-         #:color color
-         #:alpha alpha
-         #:style style
-         #:under? under?
-         #:label label
-         #:x-adjust-label x-adjust-label
-         #:y-adjust-label y-adjust-label)
-        pict?)]
   [frame (->* (pict-convertible?)
               (#:segment (or/c #f real?)
                #:color (or/c #f string? (is-a?/c color%))
@@ -275,7 +259,7 @@
        ()
        #:rest (or/c (cons/c real? (listof pict-convertible?))
                     (listof pict-convertible?))
-       pict?))
+       pict-convertible?))
 
 (define (multiple-of-four-bytes? b)
   (zero? (modulo (bytes-length b) 4)))

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -8,7 +8,7 @@
 
 (define a-number 0)
 
-(provide 
+(provide
  (except-out (all-from-out "private/main.rkt")
              use-last
              use-last*
@@ -28,11 +28,32 @@
              hb-append
              htl-append
              hbl-append
+           pin-line pin-arrow-line pin-arrows-line
              cellophane
              frame
              dc
              table)
+
+ pin-arrow-line
+ pin-arrows-line
+ pin-line
  (contract-out
+  #;
+  [pin-line
+   (->* (pict? pict-path? find/c pict-path? find/c)
+        (#:start-angle (or/c real? #f)
+         #:end-angle (or/c real? #f)
+         #:start-pull start-pull
+         #:end-pull end-pull
+         #:line-width line-width
+         #:color color
+         #:alpha alpha
+         #:style style
+         #:under? under?
+         #:label label
+         #:x-adjust-label x-adjust-label
+         #:y-adjust-label y-adjust-label)
+        pict?)]
   [frame (->* (pict-convertible?)
               (#:segment (or/c #f real?)
                #:color (or/c #f string? (is-a?/c color%))
@@ -66,22 +87,22 @@
   [htl-append *-append/c]
   [hbl-append *-append/c]
 
-  [use-last (-> pict? pict-path? pict?)]
-  [use-last* (-> pict? pict? pict?)]
-  
+  [use-last (-> pict-convertible? pict-path? pict?)]
+  [use-last* (-> pict-convertible? pict-convertible? pict?)]
+
   [colorize (-> pict-convertible? 
                 (or/c string? 
                       (is-a?/c color%)
                       (list/c byte? byte? byte?))
                 pict?)]
-                
+
   [pict->bitmap (->* (pict-convertible?)
                      ((or/c 'unsmoothed 'smoothed 'aligned))
                      (is-a?/c bitmap%))]
-  [pict->argb-pixels (->* (pict-convertible?) 
+  [pict->argb-pixels (->* (pict-convertible?)
                           ((or/c 'unsmoothed 'smoothed 'aligned))
                           (and/c bytes? multiple-of-four-bytes?))]
-  [argb-pixels->pict (-> (and/c bytes? multiple-of-four-bytes?) 
+  [argb-pixels->pict (-> (and/c bytes? multiple-of-four-bytes?)
                          exact-nonnegative-integer?
                          pict?)]
   [pin-under
@@ -181,6 +202,8 @@
                            #t)
                        [_ pict?])]))
 
+(define find/c (pict? pict-path? . -> . (values real? real?)))
+
 (define (does-draw-restore-the-state-after-being-called? draw)
   (define bdc (new bitmap-dc% [bitmap (make-bitmap 1 1)]))
   (randomize-state bdc)
@@ -199,19 +222,19 @@
   (send dc set-text-background (random-color))
   (send dc set-text-foreground (random-color))
   (send dc set-text-mode 'transparent)
-  (send dc set-font (send the-font-list find-or-create-font 
+  (send dc set-font (send the-font-list find-or-create-font
                           (+ 1 (random 254))
                           (pick-one 'default 'decorative 'roman 'script
                                     'swiss 'modern 'symbol 'system)
                           (pick-one 'normal 'italic 'slant)
                           (pick-one 'normal 'bold 'light)))
-  ;; set-transformation is relatively expensive 
+  ;; set-transformation is relatively expensive
   ;; at the moment, so we don't randomize it
   #;
   (send dc set-transformation
-        (vector (vector (random-real) (random-real) (random-real) 
-                        (random-real) (random-real) (random-real))
-                (random-real) (random-real) (random-real) (random-real) (random-real))))
+  (vector (vector (random-real) (random-real) (random-real)
+  (random-real) (random-real) (random-real))
+(random-real) (random-real) (random-real) (random-real) (random-real))))
 
 (define (random-real) (+ (random 1000) (random)))
 (define (random-color) (make-object color% (random 255) (random 255) (random 255)))
@@ -229,7 +252,7 @@
           (send dc get-transformation)
           (color->vec (send dc get-text-foreground))))
 
-(define (pen->vec pen) 
+(define (pen->vec pen)
   (vector (color->vec (send pen get-color))
           (send pen get-width)
           (send pen get-style)))
@@ -244,7 +267,7 @@
           (send font get-style)
           (send font get-weight)))
 
-(define (color->vec c) 
+(define (color->vec c)
   (vector (send c red) (send c green) (send c blue)))
 
 (define *-append/c
@@ -256,7 +279,7 @@
 
 (define (multiple-of-four-bytes? b)
   (zero? (modulo (bytes-length b) 4)))
-  
+
 (require "private/play-pict.rkt")
 (provide
  (contract-out

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -216,9 +216,9 @@
   ;; at the moment, so we don't randomize it
   #;
   (send dc set-transformation
-  (vector (vector (random-real) (random-real) (random-real)
-  (random-real) (random-real) (random-real))
-(random-real) (random-real) (random-real) (random-real) (random-real))))
+        (vector (vector (random-real) (random-real) (random-real)
+                        (random-real) (random-real) (random-real))
+                (random-real) (random-real) (random-real) (random-real) (random-real))))
 
 (define (random-real) (+ (random 1000) (random)))
 (define (random-color) (make-object color% (random 255) (random 255) (random 255)))

--- a/pict-lib/pict/private/convertible.rkt
+++ b/pict-lib/pict/private/convertible.rkt
@@ -1,20 +1,4 @@
 #lang racket/base
 (provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert
          pict-convertible-ref)
-
-(define-values (prop:pict-convertible -pict-convertible? pict-convertible-ref)
-  (make-struct-type-property 'pict-convertible))
-
-(define-values (prop:pict-convertible? pict-convertible?? pict-convertible?-ref)
-  (make-struct-type-property 'pict-convertible?))
-
-(define (pict-convertible? x)
-  (and (-pict-convertible? x)
-       (if (pict-convertible?? x)
-           ((pict-convertible?-ref x) x)
-           #t)))
-
-(define (pict-convert v)
-  (unless (pict-convertible? v)
-    (raise-type-error 'pict-convert "pict-convertible" v))
-  ((pict-convertible-ref v) v))
+(require (submod "pict.rkt" convertible))

--- a/pict-lib/pict/private/convertible.rkt
+++ b/pict-lib/pict/private/convertible.rkt
@@ -1,7 +1,4 @@
 #lang racket/base
 (provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert
-         pict-convertible-ref
-
-         prop:pict-post-equality pict-post-equality?
-         pict-post-equality-ref post-pict=?)
+         pict-convertible-ref)
 (require (submod "pict.rkt" convertible))

--- a/pict-lib/pict/private/convertible.rkt
+++ b/pict-lib/pict/private/convertible.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
-(provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert)
+(provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert
+         pict-convertible-ref)
 
 (define-values (prop:pict-convertible -pict-convertible? pict-convertible-ref)
   (make-struct-type-property 'pict-convertible))

--- a/pict-lib/pict/private/convertible.rkt
+++ b/pict-lib/pict/private/convertible.rkt
@@ -1,4 +1,7 @@
 #lang racket/base
 (provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert
-         pict-convertible-ref)
+         pict-convertible-ref
+
+         prop:pict-post-equality pict-post-equality?
+         pict-post-equality-ref post-pict=?)
 (require (submod "pict.rkt" convertible))

--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -39,10 +39,10 @@
                p)))
 
   (define (pict-path? p)
-    (or (pict? p)
+    (or (pict-convertible? p)
         (and (pair? p)
              (list? p)
-             (andmap pict? p))))
+             (andmap pict-convertible? p))))
 
   (define (label-line label pict src-pict src-coord-fn dest-pict dest-coord-fn
                       #:x-adjust [x-adjust 0] #:y-adjust [y-adjust 0])

--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -295,15 +295,9 @@
     (bitmap bm))
 
   (define (freeze p)
-    (define frozen (bitmap (pict->bitmap p)))
-    (make-pict (pict-draw frozen)
-               (pict-width p)
-               (pict-height p)
-               (pict-ascent p)
-               (pict-descent p)
-               (pict-children p)
-               (pict-panbox p)
-               (pict-last p)))
+    (define p* (pict-convert p))
+    (define frozen (bitmap (pict->bitmap p*)))
+    (struct-copy pict p* [draw (pict-draw frozen)]))
 
   (provide hline vline
            frame

--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -3,6 +3,7 @@
                       [hline t:hline]
                       [vline t:vline]
                       [frame t:frame])
+           "convertible.rkt"
            (rename-in "utils.rkt"
                       [pin-line t:pin-line]
                       [pin-arrow-line t:pin-arrow-line]
@@ -24,9 +25,10 @@
                  #:color [col #f]
                  #:line-width [lw #f]
                  #:segment [seg #f])
-    (let* ([f (if seg
-                  (dash-frame (launder (ghost p)) seg)
-                  (t:frame (launder (ghost p))))]
+    (let* ([p (pict-convert p)]
+           [f (if seg
+                     (dash-frame (launder (ghost p)) seg)
+                     (t:frame (launder (ghost p))))]
            [f (if col
                   (colorize f col)
                   f)]
@@ -294,7 +296,14 @@
 
   (define (freeze p)
     (define frozen (bitmap (pict->bitmap p)))
-    (struct-copy pict p [draw (pict-draw frozen)]))
+    (make-pict (pict-draw frozen)
+               (pict-width p)
+               (pict-height p)
+               (pict-ascent p)
+               (pict-descent p)
+               (pict-children p)
+               (pict-panbox p)
+               (pict-last p)))
 
   (provide hline vline
            frame

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -935,8 +935,9 @@
                     [(pict-convertible? p)
                      (pict-convert p)]
                     [else
-                     (error name "expected all picts as arguments, got ~a"
-                            (apply string-append (add-between (map (λ (x) (format "~e" x)) boxes*) " ")))]))
+                     (raise-argument-error
+                      name "all picts as arguments"
+                      (apply string-append (add-between (map (λ (x) (format "~e" x)) boxes*) " ")))]))
                 boxes*))
              (let ([max-w (apply max (map pict-width boxes))]
                    [max-h (apply max (map pict-height boxes))]

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -800,23 +800,23 @@
                         combine-ascent combine-descent)
            (let ([do-append
                   (lambda (sep args)
-                    (let append-boxes ([args (map pict-convert args)])
+                    (let append-boxes ([args args])
                       (cond
                        [(null? args) (blank)]
-                       [(null? (cdr args)) (car args)]
+                       [(null? (cdr args)) (pict-convert (car args))]
                        [else
-                        (let* ([first (car args)]
+                        (let* ([first (pict-convert (car args))]
                                [rest (append-boxes (cdr args))]
-                               [w (wcomb (pict-width first) (pict-width rest) sep first rest)]
-                               [h (hcomb (pict-height first) (pict-height rest) sep first rest)]
-                               [fw (pict-width first)]
-                               [fh (pict-height first)]
-                               [rw (pict-width rest)]
-                               [rh (pict-height rest)]
-                               [fd1 (pict-ascent first)]
-                               [fd2 (pict-descent first)]
-                               [rd1 (pict-ascent rest)]
-                               [rd2 (pict-descent rest)]
+                               [w (wcomb (pict-in:width first) (pict-in:width rest) sep first rest)]
+                               [h (hcomb (pict-in:height first) (pict-in:height rest) sep first rest)]
+                               [fw (pict-in:width first)]
+                               [fh (pict-in:height first)]
+                               [rw (pict-in:width rest)]
+                               [rh (pict-in:height rest)]
+                               [fd1 (pict-in:ascent first)]
+                               [fd2 (pict-in:descent first)]
+                               [rd1 (pict-in:ascent rest)]
+                               [rd2 (pict-in:descent rest)]
                                [dx1 (fxoffset fw fh rw rh sep fd1 fd2 rd1 rd2)]
                                [dy1 (fyoffset fw fh rw rh sep fd1 fd2 rd1 rd2 h)]
                                [dx2 (rxoffset fw fh rw rh sep fd1 fd2 rd1 rd2)]
@@ -826,10 +826,10 @@
                              ,w ,h
                              (put ,dx1
                                   ,dy1
-                                  ,(pict-draw first))
+                                  ,(pict-in:draw first))
                              (put ,dx2
                                   ,dy2
-                                  ,(pict-draw rest)))
+                                  ,(pict-in:draw rest)))
                            w h
                            (combine-ascent fd1 rd1 fd2 rd2 fh rh h (+ dy1 fh) (+ dy2 rh))
                            (combine-descent fd2 rd2 fd1 rd1 fh rh h (- h dy1) (- h dy2))
@@ -852,13 +852,13 @@
         [max2 (lambda (a b . args) (max a b))]
         [3+ (lambda (a b c . args) (+ a b c))]
         [a-max (lambda (a b c first rest)
-                 (+ (max (pict-ascent first) (pict-ascent rest))
-                    (max (- (pict-height first) (pict-ascent first))
-                         (- (pict-height rest) (pict-ascent rest)))))]
+                 (+ (max (pict-in:ascent first) (pict-in:ascent rest))
+                    (max (- (pict-in:height first) (pict-in:ascent first))
+                         (- (pict-in:height rest) (pict-in:ascent rest)))))]
         [d-max (lambda (a b c first rest)
-                 (+ (max (pict-descent first) (pict-descent rest))
-                    (max (- (pict-height first) (pict-descent first))
-                         (- (pict-height rest) (pict-descent rest)))))]
+                 (+ (max (pict-in:descent first) (pict-in:descent rest))
+                    (max (- (pict-in:height first) (pict-in:descent first))
+                         (- (pict-in:height rest) (pict-in:descent rest)))))]
         [min-ad (lambda (a b oa ob ah bh h da db)
                   (- h (max oa ob) (max (- ah oa a)
                                         (- bh ob b))))]
@@ -945,20 +945,20 @@
                      (error name "expected all picts as arguments, got ~a"
                             (apply string-append (add-between (map (λ (x) (format "~e" x)) boxes*) " ")))]))
                 boxes*))
-             (let ([max-w (apply max (map pict-width boxes))]
-                   [max-h (apply max (map pict-height boxes))]
-                   [max-a (apply max (map pict-ascent boxes))]
-                   [max-a-complement (apply max (map (lambda (b) (- (pict-height b) (pict-ascent b)))
+             (let ([max-w (apply max (map pict-in:width boxes))]
+                   [max-h (apply max (map pict-in:height boxes))]
+                   [max-a (apply max (map pict-in:ascent boxes))]
+                   [max-a-complement (apply max (map (lambda (b) (- (pict-in:height b) (pict-in:ascent b)))
                                                      boxes))]
                    [max-d (apply max (map pict-descent boxes))]
-                   [max-d-complement (apply max (map (lambda (b) (- (pict-height b) (pict-descent b)))
+                   [max-d-complement (apply max (map (lambda (b) (- (pict-in:height b) (pict-in:descent b)))
                                                      boxes))])
                (let ([p (picture max-w (get-th max-h max-a max-d max-a-complement max-d-complement)
                                  (map (lambda (box)
-                                        `(place ,(get-h max-w (pict-width box))
-                                                ,(get-v max-h (pict-height box)
-                                                        max-d (pict-descent box)
-                                                        max-a-complement (pict-ascent box))
+                                        `(place ,(get-h max-w (pict-in:width box))
+                                                ,(get-v max-h (pict-in:height box)
+                                                        max-d (pict-in:descent box)
+                                                        max-a-complement (pict-in:ascent box))
                                                 ,box))
                                       boxes))])
                  ;; Figure out top and bottom baselines by finding the picts again, etc:
@@ -967,15 +967,15 @@
                                     y))
                                 boxes)])
                    (let ([min-a (apply min (map (lambda (box y)
-                                                  (+ (- (pict-height p) y) (pict-ascent box)))
+                                                  (+ (- (pict-in:height p) y) (pict-in:ascent box)))
                                                 boxes ys))]
                          [min-d (apply min (map (lambda (box y)
-                                                  (+ (- y (pict-height box)) (pict-descent box)))
+                                                  (+ (- y (pict-in:height box)) (pict-in:descent box)))
                                                 boxes ys))])
-                     (make-pict (pict-draw p)
-                                (pict-width p) (pict-height p)
+                     (make-pict (pict-in:draw p)
+                                (pict-in:width p) (pict-in:height p)
                                 min-a min-d
-                                (pict-children p)
+                                (pict-in:children p)
                                 #f
                                 ;; Find bottomost, rightmost of old last picts to be the
                                 ;;  new last pict.

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -405,6 +405,7 @@
                 (lambda (pict pict-path)
                   (let ([p (let loop ([path pict-path])
                              (cond
+                               [(pict? path) path]
                                [(pict-convertible? path) (pict-convert path)]
                                [(null? (cdr path)) (loop (car path))]
                                [else (loop (cdr path))]))])
@@ -412,7 +413,7 @@
                           [h (pict-height p)]
                           [d (pict-descent p)]
                           [a (pict-ascent p)])
-                      (find-lbx (pict-convert pict) pict-path
+                      (find-lbx pict pict-path
                                 (get-x 0 1 w 0 0)
                                 (get-y 0 1 h d a))))))])
     (values (find lb rt)

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -221,7 +221,7 @@
                      in:last)      ; a descendent for the bottom-right
   #:mutable
   #:property prop:pict-convertible (λ (v) v)
-  #:property prop:pict-post-equality equal?
+  #:property prop:pict-post-equality eq?
   #:property file:prop:convertible (lambda (v mode default)
                                      (convert-pict v mode default))
   #:property prop:serializable (make-serialize-info
@@ -252,10 +252,12 @@
 (define-struct bbox (x1 y1 x2 y2 ay dy))
 
 (define (pict-convertible? x)
-    (and (-pict-convertible? x)
-         (if (pict-convertible?? x)
-             ((pict-convertible?-ref x) x)
-             #t)))
+  (if (pict? x)
+      x
+      (and (-pict-convertible? x)
+           (if (pict-convertible?? x)
+               ((pict-convertible?-ref x) x)
+               #t))))
 
 (define (pict-convert v)
   (unless (pict-convertible? v)
@@ -289,8 +291,8 @@
         (pict-post-equality-ref a)
         (lambda (a b)
           (and (converted-pict? b)
-               (equal? a (converted-pict-parent b))))))
-  (lambda (a b) (or (equal? a b) (=? a b))))
+               (eq? a (converted-pict-parent b))))))
+  (lambda (a b) (=? a b)))
 
 (module+ convertible
   (provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -160,7 +160,7 @@
     #:property prop:procedure (struct-field-index macro)
     #:property prop:struct-info
     (lambda (_)
-      (list #'struct:in:pict
+      (list #'struct:pict
             #'make-pict
             #'pict?
             (reverse (list #'pict-draw
@@ -230,6 +230,7 @@
 
 (define make-pict make-in:pict)
 (define pict? in:pict?)
+(define struct:pict struct:in:pict)
 
 (define-syntax (define-pict-setter stx)
   (syntax-case stx ()

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -186,7 +186,7 @@
    (lambda (stx)
      (syntax-case stx ()
        [(id a ...) #'(pict a ...)]
-       [id #'pict]))))
+       [id #'in:pict]))))
 
 (define-syntax (define-pict-wrap stx)
   (syntax-case stx ()
@@ -215,6 +215,7 @@
                         children   ; list of child records
                         panbox     ; panorama box, computed on demand
                         last)      ; a descendent for the bottom-right
+  #:reflection-name 'pict
   #:mutable
   #:property prop:pict-convertible (λ (v) v)
   #:property file:prop:convertible (lambda (v mode default)

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -275,12 +275,12 @@
 
 (struct converted-pict pict (parent))
 
-(define (post-pict=? a b)
+(define (pict-path-element=? a b)
   (or (eq? a b)
-      (inner-post-pict=? a b)
-      (inner-post-pict=? b a)))
+      (inner-pict-path-element=? a b)
+      (inner-pict-path-element=? b a)))
 
-(define (inner-post-pict=? a b)
+(define (inner-pict-path-element=? a b)
   (and (converted-pict? a)
        (eq? (converted-pict-parent a) b)))
 
@@ -347,7 +347,7 @@
               [not-found (lambda () (error 'find-XX
                                            "sub-pict: ~a not found in: ~a" 
                                            subbox pict))])
-    (if (post-pict=? subbox box)
+    (if (pict-path-element=? subbox box)
         (found dx dy)
         (let loop ([c (pict-children box)])
           (if (null? c)
@@ -636,19 +636,19 @@
   (let ([l (pict-last sub-p)])
     (cond
      [(not l) sub-p]
-     [(pair? l) (if (post-pict=? (car l) sub-p)
+     [(pair? l) (if (pict-path-element=? (car l) sub-p)
                     l
                     (cons sub-p l))]
-     [(post-pict=? l sub-p) sub-p]
+     [(pict-path-element=? l sub-p) sub-p]
      [else (list sub-p l)])))
 
 (define (use-last p sub-p)
   (if (let floop ([p p] [sub-p sub-p])
         (or
          (if (not (pair? sub-p))
-             (post-pict=? p sub-p)
+             (pict-path-element=? p sub-p)
              (and (not (pair? (car sub-p)))
-                  (post-pict=? p (car sub-p))
+                  (pict-path-element=? p (car sub-p))
                   (or (null? (cdr sub-p))
                       (floop p (cdr sub-p)))))
             (ormap (lambda (c) (floop (child-pict c) sub-p))

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -155,9 +155,6 @@
 (define-values (prop:pict-convertible? pict-convertible?? pict-convertible?-ref)
   (make-struct-type-property 'pict-convertible?))
 
-(define-values (prop:pict-post-equality pict-post-equality? pict-post-equality-ref)
-  (make-struct-type-property 'prop:pict-post-equality))
-
 (begin-for-syntax
   (struct pict-wrapper (macro)
     #:property prop:procedure (struct-field-index macro)
@@ -265,38 +262,31 @@
          (raise-type-error 'pict-convert "pict-convertible" v)]
         [else
          (define converted ((pict-convertible-ref v) v))
-         (if (pict-post-equality? v)
-             converted
-             (converted-pict
-              (pict-draw converted)
-              (pict-width converted)
-              (pict-height converted)
-              (pict-ascent converted)
-              (pict-descent converted)
-              (pict-children converted)
-              (pict-panbox converted)
-              (pict-last converted)
-              v))]))
+         (converted-pict
+          (pict-draw converted)
+          (pict-width converted)
+          (pict-height converted)
+          (pict-ascent converted)
+          (pict-descent converted)
+          (pict-children converted)
+          (pict-panbox converted)
+          (pict-last converted)
+          v)]))
 
-(struct converted-pict pict (parent)
-  #:property prop:pict-post-equality
-  (lambda (a b) (eq? (converted-pict-parent a) b)))
+(struct converted-pict pict (parent))
 
 (define (post-pict=? a b)
   (or (eq? a b)
       (inner-post-pict=? a b)
       (inner-post-pict=? b a)))
 
-;; pict-convertible? -> (Any Any -> Boolean)
 (define (inner-post-pict=? a b)
-  (and (pict-post-equality? a)
-       ((pict-post-equality-ref a) a b)))
+  (and (converted-pict? a)
+       (eq? (converted-pict-parent a) b)))
 
 (module+ convertible
   (provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert
-           pict-convertible-ref
-           prop:pict-post-equality pict-post-equality?
-           pict-post-equality-ref post-pict=?))
+           pict-convertible-ref))
 
 ;; ----------------------------------------
 

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -166,14 +166,14 @@
       (list #'struct:in:pict
             #'make-pict
             #'pict?
-            (list #'pict-draw
-                  #'pict-width
-                  #'pict-height
-                  #'pict-ascent
-                  #'pict-descent
-                  #'pict-children
-                  #'pict-panbox
-                  #'pict-last)
+            (reverse (list #'pict-draw
+                           #'pict-width
+                           #'pict-height
+                           #'pict-ascent
+                           #'pict-descent
+                           #'pict-children
+                           #'pict-panbox
+                           #'pict-last))
             (list #f
                   #f
                   #f

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -278,16 +278,19 @@
 
 (define (pict-path-element=? a b)
   (or (eq? a b)
-      (inner-pict-path-element=? a b)
-      (inner-pict-path-element=? b a)))
-
-(define (inner-pict-path-element=? a b)
-  (and (converted-pict? a)
-       (eq? (converted-pict-parent a) b)))
+      (if (converted-pict? a)
+          (if (converted-pict? b)
+              (eq? (converted-pict-parent a) (converted-pict-parent b))
+              (eq? (converted-pict-parent a) b))
+          (if (converted-pict? b)
+              (eq? (converted-pict-parent b) a)
+              #f))))
 
 (module+ convertible
   (provide prop:pict-convertible prop:pict-convertible? pict-convertible? pict-convert
-           pict-convertible-ref))
+           pict-convertible-ref
+
+           pict-path-element=?))
 
 ;; ----------------------------------------
 

--- a/pict-lib/pict/private/play-pict.rkt
+++ b/pict-lib/pict/private/play-pict.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require racket/list
          racket/math
-         "main.rkt")
+         "main.rkt"
+         "convertible.rkt")
 
 (provide fade-pict
          slide-pict
@@ -35,70 +36,70 @@
   (let ([orig (combine (cellophane a (- 1.0 n))
                        (cellophane b n))])
     (cond
-     [(zero? n) (refocus orig a)]
-     [(= n 1.0) (refocus orig b)]
-     [else
-      (let-values ([(atx aty) (ltl-find orig a)]
-                   [(abx aby) (rbl-find orig a)]
-                   [(btx bty) (ltl-find orig b)]
-                   [(bbx bby) (rbl-find orig b)])
-        (let ([da (+ aty (* (- bty aty) n))]
-              [dd (- (pict-height orig)
-                     (+ aby (* (- bby aby) n)))]
-              [orig 
-               ;; Generate intermediate last-pict
-               (let ([ap (or (pict-last a) a)]
-                     [bp (or (pict-last b) b)])
-                 (let-values ([(al at) (lt-find orig (if (pair? ap) (cons a ap) (list a ap)))]
-                              [(bl bt) (lt-find orig (if (pair? bp) (cons b bp) (list b bp)))]
-                              [(ae) (single-pict ap)]
-                              [(be) (single-pict bp)])
-                   (let ([ar (+ al (pict-width ae))]
-                         [ab (+ at (pict-height ae))]
-                         [br (+ bl (pict-width be))]
-                         [bb (+ bt (pict-height be))])
-                     (let ([atl (+ at (pict-ascent ae))]
-                           [abl (- ab (pict-descent ae))]
-                           [btl (+ bt (pict-ascent be))]
-                           [bbl (- bb (pict-descent be))]
-                           [btw (lambda (a b)
-                                  (+ a (* (- b a) n)))])
-                       (let ([t (btw at bt)]
-                             [l (btw al bl)])
-                         (let ([b (max t (btw ab bb))]
-                               [r (max l (btw ar br))])
-                           (let ([tl (max t (min (btw atl btl) b))]
-                                 [bl (max t (min (btw abl bbl) b))])
-                             (let ([p (blank (- r l) (- b t)
-                                             (- tl t) (- b bl))])
-                               (let ([orig+p (pin-over orig l t p)])
-                                 (use-last orig+p p))))))))))])
-          (let ([p (make-pict (pict-draw orig)
-                              (pict-width orig)
-                              (pict-height orig)
-                              da
-                              dd
-                              (list (make-child orig 0 0 1 1 0 0))
-                              #f
-                              (pict-last orig))])
-            (let ([left (+ atx (* (- btx atx) n))]
-                  [right (+ abx (* (- bbx abx) n))])
-              (let ([hp (inset p
-                               (- left)
-                               0
-                               (- right (pict-width p))
-                               0)])
-                (let-values ([(atx aty) (lt-find hp a)]
-                             [(abx aby) (lb-find hp a)]
-                             [(btx bty) (lt-find hp b)]
-                             [(bbx bby) (lb-find hp b)])
-                  (let ([top (+ aty (* (- bty aty) n))]
-                        [bottom (+ aby (* (- bby aby) n))])
-                    (inset hp
-                           0
-                           (- top)
-                           0
-                           (- bottom (pict-height hp))))))))))])))
+      [(zero? n) (refocus orig a)]
+      [(= n 1.0) (refocus orig b)]
+      [else
+       (let-values ([(atx aty) (ltl-find orig a)]
+                    [(abx aby) (rbl-find orig a)]
+                    [(btx bty) (ltl-find orig b)]
+                    [(bbx bby) (rbl-find orig b)])
+         (let ([da (+ aty (* (- bty aty) n))]
+               [dd (- (pict-height orig)
+                      (+ aby (* (- bby aby) n)))]
+               [orig 
+                ;; Generate intermediate last-pict
+                (let ([ap (or (pict-last a) a)]
+                      [bp (or (pict-last b) b)])
+                  (let-values ([(al at) (lt-find orig (if (pair? ap) (cons a ap) (list a ap)))]
+                               [(bl bt) (lt-find orig (if (pair? bp) (cons b bp) (list b bp)))]
+                               [(ae) (single-pict ap)]
+                               [(be) (single-pict bp)])
+                    (let ([ar (+ al (pict-width ae))]
+                          [ab (+ at (pict-height ae))]
+                          [br (+ bl (pict-width be))]
+                          [bb (+ bt (pict-height be))])
+                      (let ([atl (+ at (pict-ascent ae))]
+                            [abl (- ab (pict-descent ae))]
+                            [btl (+ bt (pict-ascent be))]
+                            [bbl (- bb (pict-descent be))]
+                            [btw (lambda (a b)
+                                   (+ a (* (- b a) n)))])
+                        (let ([t (btw at bt)]
+                              [l (btw al bl)])
+                          (let ([b (max t (btw ab bb))]
+                                [r (max l (btw ar br))])
+                            (let ([tl (max t (min (btw atl btl) b))]
+                                  [bl (max t (min (btw abl bbl) b))])
+                              (let ([p (blank (- r l) (- b t)
+                                              (- tl t) (- b bl))])
+                                (let ([orig+p (pin-over orig l t p)])
+                                  (use-last orig+p p))))))))))])
+           (let ([p (make-pict (pict-draw orig)
+                               (pict-width orig)
+                               (pict-height orig)
+                               da
+                               dd
+                               (list (make-child orig 0 0 1 1 0 0))
+                               #f
+                               (pict-last orig))])
+             (let ([left (+ atx (* (- btx atx) n))]
+                   [right (+ abx (* (- bbx abx) n))])
+               (let ([hp (inset p
+                                (- left)
+                                0
+                                (- right (pict-width p))
+                                0)])
+                 (let-values ([(atx aty) (lt-find hp a)]
+                              [(abx aby) (lb-find hp a)]
+                              [(btx bty) (lt-find hp b)]
+                              [(bbx bby) (lb-find hp b)])
+                   (let ([top (+ aty (* (- bty aty) n))]
+                         [bottom (+ aby (* (- bby aby) n))])
+                     (inset hp
+                            0
+                            (- top)
+                            0
+                            (- bottom (pict-height hp))))))))))])))
 
 ;; Pin `p' into `base', sliding from `p-from' to `p-to'
 ;;  (which are picts within `base') as `n' goes from 0.0 to 1.0.

--- a/pict-lib/pict/private/play-pict.rkt
+++ b/pict-lib/pict/private/play-pict.rkt
@@ -36,70 +36,70 @@
   (let ([orig (combine (cellophane a (- 1.0 n))
                        (cellophane b n))])
     (cond
-      [(zero? n) (refocus orig a)]
-      [(= n 1.0) (refocus orig b)]
-      [else
-       (let-values ([(atx aty) (ltl-find orig a)]
-                    [(abx aby) (rbl-find orig a)]
-                    [(btx bty) (ltl-find orig b)]
-                    [(bbx bby) (rbl-find orig b)])
-         (let ([da (+ aty (* (- bty aty) n))]
-               [dd (- (pict-height orig)
-                      (+ aby (* (- bby aby) n)))]
-               [orig 
-                ;; Generate intermediate last-pict
-                (let ([ap (or (pict-last a) a)]
-                      [bp (or (pict-last b) b)])
-                  (let-values ([(al at) (lt-find orig (if (pair? ap) (cons a ap) (list a ap)))]
-                               [(bl bt) (lt-find orig (if (pair? bp) (cons b bp) (list b bp)))]
-                               [(ae) (single-pict ap)]
-                               [(be) (single-pict bp)])
-                    (let ([ar (+ al (pict-width ae))]
-                          [ab (+ at (pict-height ae))]
-                          [br (+ bl (pict-width be))]
-                          [bb (+ bt (pict-height be))])
-                      (let ([atl (+ at (pict-ascent ae))]
-                            [abl (- ab (pict-descent ae))]
-                            [btl (+ bt (pict-ascent be))]
-                            [bbl (- bb (pict-descent be))]
-                            [btw (lambda (a b)
-                                   (+ a (* (- b a) n)))])
-                        (let ([t (btw at bt)]
-                              [l (btw al bl)])
-                          (let ([b (max t (btw ab bb))]
-                                [r (max l (btw ar br))])
-                            (let ([tl (max t (min (btw atl btl) b))]
-                                  [bl (max t (min (btw abl bbl) b))])
-                              (let ([p (blank (- r l) (- b t)
-                                              (- tl t) (- b bl))])
-                                (let ([orig+p (pin-over orig l t p)])
-                                  (use-last orig+p p))))))))))])
-           (let ([p (make-pict (pict-draw orig)
-                               (pict-width orig)
-                               (pict-height orig)
-                               da
-                               dd
-                               (list (make-child orig 0 0 1 1 0 0))
-                               #f
-                               (pict-last orig))])
-             (let ([left (+ atx (* (- btx atx) n))]
-                   [right (+ abx (* (- bbx abx) n))])
-               (let ([hp (inset p
-                                (- left)
-                                0
-                                (- right (pict-width p))
-                                0)])
-                 (let-values ([(atx aty) (lt-find hp a)]
-                              [(abx aby) (lb-find hp a)]
-                              [(btx bty) (lt-find hp b)]
-                              [(bbx bby) (lb-find hp b)])
-                   (let ([top (+ aty (* (- bty aty) n))]
-                         [bottom (+ aby (* (- bby aby) n))])
-                     (inset hp
-                            0
-                            (- top)
-                            0
-                            (- bottom (pict-height hp))))))))))])))
+     [(zero? n) (refocus orig a)]
+     [(= n 1.0) (refocus orig b)]
+     [else
+      (let-values ([(atx aty) (ltl-find orig a)]
+                   [(abx aby) (rbl-find orig a)]
+                   [(btx bty) (ltl-find orig b)]
+                   [(bbx bby) (rbl-find orig b)])
+        (let ([da (+ aty (* (- bty aty) n))]
+              [dd (- (pict-height orig)
+                     (+ aby (* (- bby aby) n)))]
+              [orig 
+               ;; Generate intermediate last-pict
+               (let ([ap (or (pict-last a) a)]
+                     [bp (or (pict-last b) b)])
+                 (let-values ([(al at) (lt-find orig (if (pair? ap) (cons a ap) (list a ap)))]
+                              [(bl bt) (lt-find orig (if (pair? bp) (cons b bp) (list b bp)))]
+                              [(ae) (single-pict ap)]
+                              [(be) (single-pict bp)])
+                   (let ([ar (+ al (pict-width ae))]
+                         [ab (+ at (pict-height ae))]
+                         [br (+ bl (pict-width be))]
+                         [bb (+ bt (pict-height be))])
+                     (let ([atl (+ at (pict-ascent ae))]
+                           [abl (- ab (pict-descent ae))]
+                           [btl (+ bt (pict-ascent be))]
+                           [bbl (- bb (pict-descent be))]
+                           [btw (lambda (a b)
+                                  (+ a (* (- b a) n)))])
+                       (let ([t (btw at bt)]
+                             [l (btw al bl)])
+                         (let ([b (max t (btw ab bb))]
+                               [r (max l (btw ar br))])
+                           (let ([tl (max t (min (btw atl btl) b))]
+                                 [bl (max t (min (btw abl bbl) b))])
+                             (let ([p (blank (- r l) (- b t)
+                                             (- tl t) (- b bl))])
+                               (let ([orig+p (pin-over orig l t p)])
+                                 (use-last orig+p p))))))))))])
+          (let ([p (make-pict (pict-draw orig)
+                              (pict-width orig)
+                              (pict-height orig)
+                              da
+                              dd
+                              (list (make-child orig 0 0 1 1 0 0))
+                              #f
+                              (pict-last orig))])
+            (let ([left (+ atx (* (- btx atx) n))]
+                  [right (+ abx (* (- bbx abx) n))])
+              (let ([hp (inset p
+                               (- left)
+                               0
+                               (- right (pict-width p))
+                               0)])
+                (let-values ([(atx aty) (lt-find hp a)]
+                             [(abx aby) (lb-find hp a)]
+                             [(btx bty) (lt-find hp b)]
+                             [(bbx bby) (lb-find hp b)])
+                  (let ([top (+ aty (* (- bty aty) n))]
+                        [bottom (+ aby (* (- bby aby) n))])
+                    (inset hp
+                           0
+                           (- top)
+                           0
+                           (- bottom (pict-height hp))))))))))])))
 
 ;; Pin `p' into `base', sliding from `p-from' to `p-to'
 ;;  (which are picts within `base') as `n' goes from 0.0 to 1.0.

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -6,6 +6,7 @@
            racket/math
            file/convertible
            racket/gui/dynamic
+           "convertible.rkt"
            "pict.rkt")
 
   (provide cons-colorized-picture
@@ -67,13 +68,13 @@
              (andmap pict? p))))
   
   (provide/contract 
-   [scale (case-> (-> pict? number? number? pict?)
-                  (-> pict? number? pict?))]
-   [scale-to-fit (->* (pict? (or/c number? pict?))
+   [scale (case-> (-> pict-convertible? number? number? pict?)
+                  (-> pict-convertible? number? pict?))]
+   [scale-to-fit (->* (pict-convertible? (or/c number? pict-convertible?))
                       (number? #:mode (or/c 'preserve 'inset 'distort))
                       pict?)]
-   [rotate (case-> (-> pict? number? pict?))]
-   [pin-line (->* (pict?
+   [rotate (case-> (-> pict-convertible? number? pict?))]
+   [pin-line (->* (pict-convertible?
                    pict-path? (-> pict? pict-path? (values number? number?))
                    pict-path? (-> pict? pict-path? (values number? number?)))
                   ((or/c false/c number?)
@@ -82,7 +83,7 @@
                    #:style (or/c false/c symbol?))
                   pict?)]
    [pin-arrow-line (->* (number?
-                         pict?
+                         pict-convertible?
                          pict-path? (-> pict? pict-path? (values number? number?))
                          pict-path? (-> pict? pict-path? (values number? number?)))
                         ((or/c false/c number?) 
@@ -92,9 +93,9 @@
                          #:style (or/c false/c symbol?)
                          #:hide-arrowhead? any/c)
                         pict?)]
-   [pin-arrows-line (->* (number? pict?
-                           pict-path? (-> pict? pict-path? (values number? number?))
-                           pict-path? (-> pict? pict-path? (values number? number?)))
+   [pin-arrows-line (->* (number? pict-convertible?
+                           pict-path? (-> pict-convertible? pict-path? (values number? number?))
+                           pict-path? (-> pict-convertible? pict-path? (values number? number?)))
                           ((or/c false/c number?)
                            (or/c false/c string?)
                            boolean?
@@ -1097,7 +1098,7 @@
                         #:mode [mode 'preserve]) ; or: 'inset 'distort
     (cond [(not h-or-false) ; scale to the size of another pict
            (define size-pict w-or-size-pict)
-           (unless (pict? size-pict)
+           (unless (pict-convertible? size-pict)
              (raise-type-error 'scale-to-fit "pict?" size-pict))
            (scale-to-fit main-pict
                          (pict-width size-pict)

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -1188,32 +1188,33 @@
   (define cellophane
     (case-lambda
      [(p alpha-factor)
-      (cond
-       [(= 1.0 alpha-factor)
-        (inset p 0)]
-       [(zero? alpha-factor)
-        (ghost p)]
-       [else
-        (let ([drawer (make-pict-drawer p)])
-          (let ([new
-                 (dc
-                  (lambda (dc x y)
-                    (let ([a (send dc get-alpha)])
-                      (send dc set-alpha (* a alpha-factor))
-                      (drawer dc x y)
-                      (send dc set-alpha a)))
-                  (pict-width p)
-                  (pict-height p)
-                  (pict-ascent p)
-                  (pict-descent p))])
-            (make-pict (pict-draw new)
-                       (pict-width new)
-                       (pict-height new)
-                       (pict-ascent new)
-                       (pict-descent new)
-                       (list (make-child p 0 0 1 1 0 0))
-                       #f
-                       (pict-last p))))])]))
+      (let ([p (pict-convert p)])
+        (cond
+          [(= 1.0 alpha-factor)
+           (inset p 0)]
+          [(zero? alpha-factor)
+           (ghost p)]
+          [else
+           (let ([drawer (make-pict-drawer p)])
+             (let ([new
+                    (dc
+                     (lambda (dc x y)
+                       (let ([a (send dc get-alpha)])
+                         (send dc set-alpha (* a alpha-factor))
+                         (drawer dc x y)
+                         (send dc set-alpha a)))
+                     (pict-width p)
+                     (pict-height p)
+                     (pict-ascent p)
+                     (pict-descent p))])
+               (make-pict (pict-draw new)
+                          (pict-width new)
+                          (pict-height new)
+                          (pict-ascent new)
+                          (pict-descent new)
+                          (list (make-child p 0 0 1 1 0 0))
+                          #f
+                          (pict-last p))))]))]))
 
   (define inset/clip
     (case-lambda

--- a/pict-lib/pict/shadow.rkt
+++ b/pict-lib/pict/shadow.rkt
@@ -6,18 +6,19 @@
          racket/draw
          racket/future
          racket/math
-         pict)
+         pict
+         "convert.rkt")
 
 (define nneg-real/c (and/c real? (not/c negative?)))
 
 (provide/contract
  [blur
-  (->* (pict? nneg-real/c)
+  (->* (pict-convertible? nneg-real/c)
        (nneg-real/c
         #:pre-inset? any/c)
        pict?)]
  [shadow
-  (->* (pict? nneg-real/c)
+  (->* (pict-convertible? nneg-real/c)
        (real? real?
         #:color (or/c #f string? (is-a?/c color%))
         #:shadow-color (or/c #f string? (is-a?/c color%)))
@@ -35,7 +36,7 @@
         #:blur (and/c real? (not/c negative?))
         #:margin real?
         #:sep real?)
-       #:rest (listof pict?)
+       #:rest (listof pict-convertible?)
        pict?)])
 
 ;; ----

--- a/pict-lib/pict/tree-layout.rkt
+++ b/pict-lib/pict/tree-layout.rkt
@@ -3,6 +3,7 @@
          racket/class
          racket/draw
          "main.rkt"
+         "convert.rkt"
          "private/tidier.rkt"
          "private/layout.rkt"
          "private/hv.rkt"
@@ -13,7 +14,7 @@
   [rename _tree-layout
           tree-layout
           (->* () 
-               (#:pict pict?) 
+               (#:pict pict-convertible?) 
                #:rest (listof (or/c tree-edge? tree-layout? #f))
                tree-layout?)]
   [rename _tree-edge

--- a/pict-lib/texpict/code.rkt
+++ b/pict-lib/texpict/code.rkt
@@ -1,5 +1,6 @@
 (module code racket/base
   (require pict/private/pict
+           pict/convert
            (prefix-in r: racket/base)
            mzlib/class
            mzlib/list
@@ -544,7 +545,7 @@
                     (apply htl-append 
                            (color-semi-p)
                            (map (lambda (s)
-                                  (if (pict? (syntax-e s))
+                                  (if (pict-convertible? (syntax-e s))
                                       (syntax-e s)
                                       (maybe-colorize (tt (syntax-e s)) (current-comment-color))))
                                 (syntax->list #'(s ...))))])
@@ -715,7 +716,7 @@
                                     closes
                                     mode))]
             [else
-	     (add-close (if (pict? (syntax-e stx))
+	     (add-close (if (pict-convertible? (syntax-e stx))
 			    (syntax-e stx)
 			    (mode-colorize mode 'literal
 					   (tt (format "~s" (syntax-e stx)))))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -299,7 +299,7 @@
 (test-case "check pict-post"
   (local-require (submod pict/private/pict convertible))
   (let ([x (wrap (text "xx"))])
-    (check-true (post-pict=? x (pict-convert x)))))
+    (check-true (pict-path-element=? x (pict-convert x)))))
 
 (test-case "find-XX with wrapping tests"
   (check-not-exn

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -346,6 +346,7 @@
                           ...))
                  `(m ,(last i) ...))))])])))
 
+(require (prefix-in htdp: 2htdp/image))
 (define (generate-pict/wrap)
   (define-values (l p m)
     (let loop ([fuel 20])
@@ -353,12 +354,13 @@
       (define (gen [fuel-cut (cut)])
         (loop (floor (/ (sub1 fuel) fuel-cut))))
       (gen-wrapping-case gen cut count
-       (if (= fuel 0) (random 5) (random count))
+       (if (= fuel 0) (random 6) (random count))
        (text "sefsefse")
        (rectangle (add1 (random 10)) (add1 (random 10)))
        (arrow (add1 (random 10)) (add1 (random 10)))
        (jack-o-lantern (add1 (random 10)))
        (standard-fish 100 50)
+       (htdp:triangle (add1 (random 40)) "solid" "tan")
        ;; disabled because this + linestyle can cause cairo to segfault...
        #;(thermometer)
        (frame (gen))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -378,6 +378,8 @@
         (colorize (gen) (list (random 254) (random 254) (random 254)))
         (cellophane (gen) (random))
         (clip (gen))
+        (clip-descent (gen))
+        (clip-ascent (gen))
         (freeze (gen))
         (blur (gen) (add1 (random 10)))
         (shadow-frame (gen))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -361,8 +361,7 @@
        (jack-o-lantern (add1 (random 10)))
        (standard-fish 100 50)
        (htdp:triangle (add1 (random 40)) "solid" "tan")
-       ;; disabled because this + linestyle can cause cairo to segfault...
-       #;(thermometer)
+       (thermometer)
        (frame (gen))
        (cc-superimpose (gen) (gen))
        (vl-append (gen) (gen))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -353,10 +353,14 @@
       (define (gen [fuel-cut (cut)])
         (loop (floor (/ (sub1 fuel) fuel-cut))))
       (gen-wrapping-case gen cut count
-       (if (= fuel 0) (random 3) (random count))
+       (if (= fuel 0) (random 5) (random count))
        (text "sefsefse")
        (rectangle (add1 (random 10)) (add1 (random 10)))
        (arrow (add1 (random 10)) (add1 (random 10)))
+       (jack-o-lantern (add1 (random 10)))
+       (standard-fish 100 50)
+       ;; disabled because this + linestyle can cause cairo to segfault...
+       #;(thermometer)
        (frame (gen))
        (cc-superimpose (gen) (gen))
        (vl-append (gen) (gen))
@@ -436,9 +440,9 @@
                      [(f) (random)])
           (with-handlers ([void (lambda (e)
                                   (displayln `(slide-pict ,m3
-                                                          (hbl-append ,m1 m2)
-                                                          m1
-                                                          m2
+                                                          (hbl-append ,m1 ,m2)
+                                                          ,m1
+                                                          ,m2
                                                           ,f))
                                   (raise e))])
             (define (mk i l r)


### PR DESCRIPTION
This PR allows anything that is `pict-convertible?` to be used where a `pict` can be used. It also adds a lot of tests for this library.

The changes have not made it to the documentation yet. I would like code/design review before that.

List of changes:

- Wrap the `pict` struct info to provide versions of the accessors that automatically convert `pict-convertible?`s.
- Stop exporting `set-pict-width!` and friends.
- Add several explicit pict conversions to make some things fast, and to have them behave in the expected behavior.
- Add a new property for `pict`s that will allow uses to define how their `pict-convertible?` struct is compared to `pict`s (that may have been converted from the same struct). This is to allow things like `pin-arrow-lines` to behave in an intuitive manner when finding things that have been converted form the same `pict-convertible?` struct. By default this property is implemented by storing the original `pict-convertible?` in an extra field, and checking `eq?`ness.
- Add a large randomized test suite to test these changes.

I've tested the speed using the framework in [stamourv/contract-benchmarks](https://github.com/stamourv/contract-benchmarks) for checking slideshow benchmarks. I see about a 10% slowdown between the current git HEAD and this PR. I can attempt to make this better if that seems too high.