### PR TITLE
straighten devil tail

### DIFF
--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -685,19 +685,19 @@
 			(send dc draw-polygon horn 70 -15))
 		      
 		      (send dc draw-polygon (list
-					     (make-object point% 0 0)
-					     (make-object point% 10 2)
-					     (make-object point% 0 6))
-			    115 32)
+					     (make-object point% 3 -2)
+					     (make-object point% -8 0)
+					     (make-object point% 1 -6))
+			    96 75)
 		      
 		      (send dc set-pen (send the-pen-list
 					     find-or-create-pen
 					     "red"
 					     2
 					     'solid))
-		      (send dc draw-line 101 55 110 55)
-		      (send dc draw-spline 110 55   130 50    110  45)
-		      (send dc draw-spline 110 45   90 40    115  35)))
+		      (send dc draw-spline 101 55   113 60    102  62)
+		      (send dc draw-spline 102 62   92 65    103  67)
+		      (send dc draw-spline 103 67   109 70   100  71)))
 		    
 		  (send dc set-origin dx dy)
 
@@ -1359,3 +1359,4 @@
        (* large-rad 2)
        0
        0)))
+


### PR DESCRIPTION
Changes the tail on `(desktop-machine ... '(devil ...))` from this:
![screen shot 2016-09-07 at 17 58 04](https://cloud.githubusercontent.com/assets/1731829/18330103/c42d2b34-7524-11e6-864a-4ec841a64798.png)

to this:
![screen shot 2016-09-07 at 18 01 33](https://cloud.githubusercontent.com/assets/1731829/18330293/add25444-7525-11e6-9648-494d4f34be96.png)

Because the (cropped) old tail looks more like cat whiskers or a duck face.
