### PR TITLE
contracts for dingbats

### DIFF
--- a/pict-doc/pict/scribblings/more.scrbl
+++ b/pict-doc/pict/scribblings/more.scrbl
@@ -87,7 +87,8 @@ partially open.
 
 @defproc[(jack-o-lantern [size real?]
                          [pumpkin-color (or/c string? (is-a?/c color%)) "orange"] 
-                         [face-color (or/c string? (is-a?/c color%)) "black"])
+                         [face-color (or/c string? (is-a?/c color%)) "black"]
+                         [stem-color (or/c string? (is-a?/c color%)) "brown"])
          pict?]{
 
 Creates a jack-o-lantern; use the same pumpkin and face color to get a
@@ -95,7 +96,7 @@ plain pumpkin. The @racket[size] determines the width.
 
 @examples[#:eval ss-eval
   (jack-o-lantern 100)
-  (jack-o-lantern 100 "cadet blue" "khaki")
+  (jack-o-lantern 100 "cadet blue" "khaki" "salmon")
 ]}
 
 @defproc[(angel-wing [w real?]
@@ -139,13 +140,13 @@ The @racket[style] can include any of the following:
                
 @defproc[(thermometer [#:height-% height-% (between/c 0 1) 1]
                       [#:color-% color-% (between/c 0 1) height-%]
-                      [#:ticks ticks non-exact-negative-integer? 4]
+                      [#:ticks ticks exact-nonnegative-integer? 4]
                       [#:start-color start-color (or/c string? (is-a?/c color%)) "lightblue"]
                       [#:end-color end-color (or/c string? (is-a?/c color%)) "lightcoral"]
-                      [#:top-circle-diameter top-circle-diameter positive-real? 40]
-                      [#:bottom-circle-diameter bottom-circle-diameter positive-real? 80]
-                      [#:stem-height stem-height positive-real? 180]
-                      [#:mercury-inset mercury-inset positive-real? 8])
+                      [#:top-circle-diameter top-circle-diameter (>/c 0) 40]
+                      [#:bottom-circle-diameter bottom-circle-diameter (>/c 0) 80]
+                      [#:stem-height stem-height (>/c 0) 180]
+                      [#:mercury-inset mercury-inset (>/c 0) 8])
          pict?]{
   Produces a thermometer that consists of a semi-circle on top of a rectangle on
   top of a circle. The sizes of the three components are controlled via the
@@ -153,14 +154,14 @@ The @racket[style] can include any of the following:
   arguments. 
   
   The mercury is drawn the same way, but by creating the three components inset from the
-  versions that draw the boundary of the thermometer. This inset is conrolled by the
+  versions that draw the boundary of the thermometer. This inset is controlled by the
   @racket[mercury-inset] argument.
   
   The height of the mercury in the thermometer is controlled by the @racket[height-%] argument.
   Its color is interpolated between the @racket[start-color] and @racket[end-color], as 
   determined by the @racket[color-%] argument. 
   
-  Finally, some number of ticks are drawn, basd on the @racket[ticks] argument.
+  Finally, some number of ticks are drawn, based on the @racket[ticks] argument.
   
 @examples[#:eval ss-eval
   (thermometer #:stem-height 90

--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -8,7 +8,7 @@
                       [pin-line t:pin-line]
                       [pin-arrow-line t:pin-arrow-line]
                       [pin-arrows-line t:pin-arrows-line])
-           (only-in racket/draw dc-path% make-bitmap bitmap% bitmap-dc%)
+           (only-in racket/draw dc-path% make-bitmap bitmap% bitmap-dc% color%)
            (only-in racket/class new send make-object is-a?/c)
            racket/contract)
 
@@ -426,10 +426,45 @@
 
                        explode-star
 
+                       cloud
+                       file-icon
                        standard-fish
+                       jack-o-lantern
+                       angel-wing
+                       desktop-machine
+                       thermometer
 
                        find-pen find-brush)
-           (rename-out [fish standard-fish])
+           (contract-out
+            [cloud (->* [real? real?]
+                        [(or/c string? (is-a?/c color%))
+                         #:style (listof (or/c 'square 'nw 'ne 'sw 'se 'wide))]
+                       pict?)]
+            [file-icon (->* [real? real? any/c] [any/c] pict?)]
+            [rename fish standard-fish (->* [real? real?]
+                                            [#:direction (or/c 'left 'right)
+                                             #:color (or/c string? (is-a?/c color%))
+                                             #:eye-color (or/c string? (is-a?/c color%) #f)
+                                             #:open-mouth (or/c boolean? (between/c 0 1))]
+                                            pict?)]
+            [jack-o-lantern (->* [real?]
+                                 [(or/c string? (is-a?/c color%))
+                                  (or/c string? (is-a?/c color%))
+                                  (or/c string? (is-a?/c color%))]
+                                 pict?)]
+            [angel-wing (-> real? real? any/c pict?)]
+            [desktop-machine (->* [real?] [(listof symbol?)] pict?)]
+            [thermometer (->* []
+                              [#:height-% (between/c 0 1)
+                               #:color-% (between/c 0 1)
+                               #:ticks exact-nonnegative-integer?
+                               #:start-color (or/c string? (is-a?/c color%))
+                               #:end-color (or/c string? (is-a?/c color%))
+                               #:top-circle-diameter (>/c 0)
+                               #:bottom-circle-diameter (>/c 0)
+                               #:stem-height (>/c 0)
+                               #:mercury-inset (>/c 0)]
+                              pict?)])
            pict->bitmap
            pict->argb-pixels
            argb-pixels->pict))

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -469,7 +469,7 @@
           s))
     (define start-color (to-color _start-color))
     (define end-color (to-color _end-color))
-    (define (between lo hi) (round (+ lo (* (- hi lo) color-%))))
+    (define (between lo hi) (exact-round (+ lo (* (- hi lo) color-%))))
     (define fill-color (make-object color%
                          (between (send start-color red) (send end-color red))
                          (between (send start-color green) (send end-color green))

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -532,6 +532,119 @@
    (pict-height
     (clip-ascent (blur (text "sefsefse") 10))))))
 
+;;;; contract tests
+
+(test-case "dingbats-contracts"
+  ;; test correct calls
+  (check-not-exn (λ () (cloud 2 2 "orange" #:style '(square nw ne se sw wide))))
+  (check-not-exn (λ () (file-icon 2 2 'anything 'anything)))
+  (check-not-exn (λ () (standard-fish 2 2 #:direction 'left #:color "red" #:eye-color "blue" #:open-mouth 0.2)))
+  (check-not-exn (λ () (jack-o-lantern 2 "red" "blue" "yellow")))
+  (check-not-exn (λ () (angel-wing 2 2 '())))
+  (check-not-exn (λ () (desktop-machine 1 '(plt devil binary other))))
+  (check-not-exn (λ () (thermometer #:height-% 1
+                                    #:color-% 0.8
+                                    #:ticks 2
+                                    #:start-color "red"
+                                    #:end-color "white"
+                                    #:top-circle-diameter 8
+                                    #:bottom-circle-diameter 10
+                                    #:stem-height 5
+                                    #:mercury-inset 2)))
+
+  ;; test contract errors
+  (check-exn exn:fail:contract?
+    (λ () (cloud 'a 2 "orange" #:style '(square nw ne se sw wide))))
+  (check-exn exn:fail:contract?
+    (λ () (cloud 2 'b "orange" #:style '(square nw ne se sw wide))))
+  (check-exn exn:fail:contract?
+    (λ () (cloud 2 2 4 #:style '(square nw ne se sw wide))))
+  (check-exn exn:fail:contract?
+    (λ () (cloud 2 2 #:style '(none))))
+
+  (check-exn exn:fail:contract?
+    (λ () (file-icon 'y 2 "red" 'shaded)))
+  (check-exn exn:fail:contract?
+    (λ () (file-icon 2 'x #t)))
+
+  (check-exn exn:fail:contract?
+    (λ () (standard-fish 'nan 2 #:direction 'left #:color "red" #:eye-color "blue" #:open-mouth 0.2)))
+  (check-exn exn:fail:contract?
+    (λ () (standard-fish 2 3+1i #:direction 'left #:color "red" #:eye-color "blue" #:open-mouth 0.2)))
+  (check-exn exn:fail:contract?
+    (λ () (standard-fish 2 2 #:direction 'up #:color "red" #:eye-color "blue" #:open-mouth 0.2)))
+  (check-exn exn:fail:contract?
+    (λ () (standard-fish 2 2 #:direction 'left #:color #f #:eye-color "blue" #:open-mouth 0.2)))
+  (check-exn exn:fail:contract?
+    (λ () (standard-fish 2 2 #:direction 'left #:color "red" #:eye-color #t #:open-mouth 9)))
+
+  (check-exn exn:fail:contract?
+    (λ () (jack-o-lantern 'x "red" "blue" "yellow")))
+  (check-exn exn:fail:contract?
+    (λ () (jack-o-lantern 2 #f "blue" "yellow")))
+  (check-exn exn:fail:contract?
+    (λ () (jack-o-lantern 2 "red" #f "yellow")))
+  (check-exn exn:fail:contract?
+    (λ () (jack-o-lantern 2 "red" "blue" #f)))
+  (check-exn exn:fail:contract?
+    (λ () (jack-o-lantern 100 50))) ;; From racket/pict GitHub issue #26
+
+  (check-exn exn:fail:contract?
+    (λ () (angel-wing #f 2 '())))
+  (check-exn exn:fail:contract?
+    (λ () (angel-wing 2 #f '())))
+
+  (check-exn exn:fail:contract?
+    (λ () (desktop-machine 3+2i '(plt devil binary other))))
+  (check-exn exn:fail:contract?
+    (λ () (desktop-machine 1 '("plt"))))
+
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 2 #:color-% 0.8 #:ticks 2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% -0.8 #:ticks 2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2.2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2 #:start-color #f
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2 #:start-color "red"
+                       #:end-color #f #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter -2
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter -2 #:stem-height 5
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 0
+                       #:mercury-inset 2)))
+  (check-exn exn:fail:contract?
+    (λ () (thermometer #:height-% 1 #:color-% 0.8 #:ticks 2 #:start-color "red"
+                       #:end-color "white" #:top-circle-diameter 8
+                       #:bottom-circle-diameter 10 #:stem-height 5
+                       #:mercury-inset 0))))
+
 ;;;; other tests
 
 ;; check that pict constructor works


### PR DESCRIPTION
For #26 

Add contracts to the pict dingbats constructors, also:
- document the `stem-color` argument of `jack-o-lantern`
- fix typos in the `thermometer` documentation