### PR TITLE
fix typos

### DIFF
--- a/pict-doc/pict/scribblings/anim.scrbl
+++ b/pict-doc/pict/scribblings/anim.scrbl
@@ -14,7 +14,7 @@ slide constructors in @racketmodname[slideshow/play].
 
 @declare-exporting[pict slideshow/play]
 
-@section{Pict Interoplations}
+@section{Pict Interpolations}
 
 @defproc[(fade-pict [n (real-in 0.0 1.0)] [p1 pict?] [p2 pict?]
                     [#:combine combine (pict? pict? . -> . pict?) cc-superimpose])
@@ -210,7 +210,7 @@ The @racket[fast-end] mapping is concave, so that
 
 @racketblock[(slide-pict _base _p _p1 _p2 (fast-end _n))]
 
-appears to move slowly away from @racket[_p1] and then quicly as it
+appears to move slowly away from @racket[_p1] and then quickly as it
 approaches @racket[_p2], assuming that @racket[_n] increases uniformly.
 
 @examples[#:eval ss-eval #:label #f

--- a/pict-doc/pict/scribblings/code.scrbl
+++ b/pict-doc/pict/scribblings/code.scrbl
@@ -272,7 +272,7 @@ If a @racket[_datum] contains @racket[(escape-id _expr)]---perhaps as
 the @racket[_expr] is evaluated and the result datum is spliced in
 place of the @racket[escape-id] form in @racket[_datum]. If the result
 is not a syntax object, it is given the source location of the
-@racket[escape-id] form. A pict value intected this way as a
+@racket[escape-id] form. A pict value injected this way as a
 @racket[_datum] is rendered as itself.
 
 If a @racket[_datum] contains @racket[(transform-id _datum ...)] or

--- a/pict-doc/pict/scribblings/color.scrbl
+++ b/pict-doc/pict/scribblings/color.scrbl
@@ -39,7 +39,7 @@ These functions apply appropriate colors to picture @racket[p].
 @defproc[(dark [color color/c]) color/c]
 )]{
 
-These functions produce ligher or darker versions of a color.
+These functions produce lighter or darker versions of a color.
 
 @examples[#:eval the-eval
 (hc-append (colorize (disk 20) "red")

--- a/pict-doc/pict/scribblings/more.scrbl
+++ b/pict-doc/pict/scribblings/more.scrbl
@@ -199,8 +199,8 @@ negative, etc.
 
 The @racket[color] argument is the background color for the balloon.
 
-The @racket[corner-radius] argument determines the radius of the cicle
-used to roun the balloon's corners. As usual, if it is less than
+The @racket[corner-radius] argument determines the radius of the circle
+used to round the balloon's corners. As usual, if it is less than
 @racket[1], then it acts as a ratio of the balloon's width or height.
 
 The result is a balloon, not a pict. The @racket[balloon-pict]


### PR DESCRIPTION
Fix a typo reported by J. Fuller in [Bug 15414](https://bugs.racket-lang.org/query/?cmd=view%20audit-trail&database=default&pr=15414) and a few more.

But I'm not sure about this:

-`@racket[escape-id]` form. A pict value **intected** this way as a 

+`@racket[escape-id]` form. A pict value **injected** this way as a
