### PR TITLE
Make coloring in codeblock-pict more consistent with code

### DIFF
--- a/pict-lib/pict/code.rkt
+++ b/pict-lib/pict/code.rkt
@@ -214,9 +214,14 @@
       [(constant) literal-color]
       [(hash-colon-keyword) base-color]
       [else "black"])) ; 'other, or others. to align with DrRacket
+  (define (in-keyword-list? token)
+    (member token (current-keyword-list)))
   (define (token->pict t)
     (match-define `(,token . ,type) t)
-    (colorize (tt token) (token-class->color type)))
+    (define color
+      (cond [(in-keyword-list? token) keyword-color]
+            [else (token-class->color type)]))
+    (colorize (tt token) color))
   (define (not-newline? x) (not (equal? (car x) "\n")))
   (define lines
     (let loop ([ts ts])

--- a/pict-lib/pict/code.rkt
+++ b/pict-lib/pict/code.rkt
@@ -205,14 +205,14 @@
   (define (token-class->color c)
     (case c
       [(symbol) id-color]
-      [(keyword) id-color] ; We don't have a keyword color?
+      [(keyword) keyword-color]
       [(white-space) "white"]
       [(comment) comment-color]
       [(no-color) base-color]
       [(parenthesis) base-color] ; really? pict has no color for parens?
       [(string) literal-color]
       [(constant) literal-color]
-      [(hash-colon-keyword) keyword-color]
+      [(hash-colon-keyword) base-color]
       [else "black"])) ; 'other, or others. to align with DrRacket
   (define (token->pict t)
     (match-define `(,token . ,type) t)


### PR DESCRIPTION
This PR should make the coloring for `codeblock-pict` look more like `code`. Here are some example snippets that will show the current differences if you run them in DrRacket:

```
(require pict/code)
(codeblock-pict "#:foo")
(code #:foo)
(codeblock-pict "define")
(code define)
```