### PR TITLE
Fix English mistake in documentation

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -21,7 +21,7 @@
 @defmodule*/no-declare[(pict)]{ The
 @racketmodname[pict] library is one of the standard Racket
 functional picture libraries (the other being @racketmodname[2htdp/image #:indirect]).
-This library was original designed for use with 
+This library was originally designed for use with
 @seclink[#:doc '(lib "scribblings/slideshow/slideshow.scrbl") "top"]{Slideshow},
 and is re-provided by the @racketmodname[slideshow] language.}
 


### PR DESCRIPTION
'was original designed...' -> 'was originally designed...'