### PR TITLE
doc: add extra hline example,

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -310,6 +310,7 @@ Straight lines, centered within their @tech{bounding box}es.
 
 @examples[#:eval ss-eval
   (hline 40 5)
+  (hline 40 30)
   (vline 5 40 #:segment 5)
 ]}
 


### PR DESCRIPTION
to show the width argument only changes the bounding box --- and not
the line width