### PR TITLE
Removes srcloc attached to stx define-code passes to given typeset-code

### DIFF
--- a/pict-lib/texpict/code.rkt
+++ b/pict-lib/texpict/code.rkt
@@ -152,7 +152,7 @@
 	      #`(typeset-code #,(cvt
                                  ;; Avoid a syntax location for the synthesized `code:line` wrapper,
                                  ;; otherwise the `expr`s will be arranged relative to it:
-                                 (datum->syntax #f (cons 'code:line #'(expr (... ...))))))])))]
+                                 (datum->syntax #f (cons 'code:line (datum->syntax #f (syntax-e #'(expr (... ...))))))))])))]
       [(_ code typeset-code) #'(define-code code typeset-code unsyntax)]))
   
   (define-signature code^


### PR DESCRIPTION
Before it would give a syntax object with line 155, which is the
location of the syntax object in texpict/code. This can mess up variants
of typeset-code that track the source location of the top most syntax
object.