### PR TITLE
Add linestyle to tree-edge

### DIFF
--- a/pict-doc/pict/scribblings/tree-layout.scrbl
+++ b/pict-doc/pict/scribblings/tree-layout.scrbl
@@ -37,6 +37,12 @@ that render them as @racket[pict]s.
                                   "gray"]
                     [#:edge-width edge-width
                                   (or/c 'unspecified real? #f)
+                                  'unspecified]
+                    [#:edge-style edge-style
+                                  (or/c 'unspecified 'transparent 'solid 'xor 'hilite
+                                        'dot 'long-dash 'short-dash 'dot-dash
+                                        'xor-dot 'xor-long-dash 'xor-short-dash
+                                        'xor-dot-dash)
                                   'unspecified])
          tree-edge?]{
   This function specifies an edge from some parent to the given @racket[node].
@@ -46,14 +52,19 @@ that render them as @racket[pict]s.
   set. This is intended to allow the line width to be set for the whole pict
   via @racket[linewidth]. Otherwise, @racket[edge-width] is interpreted the
   same way as the width argument for the @racket[linewidth] function.
+  @racket[edge-style] behaves similarly, its argument interpreted as the style
+  argument for the @racket[linestyle] function.
 
   @examples[#:eval
             tree-layout-eval
             (naive-layered (tree-layout
                             (tree-edge #:edge-width 3 (tree-layout))
-                            (tree-edge #:edge-color "green" (tree-layout))))]
+                            (tree-edge #:edge-color "red"
+                                       #:edge-style 'dot
+                                       (tree-layout))))]
 
   @history[#:changed "6.1.0.5" "Added an #:edge-width option"]
+  @; TODO: Add history comment re edge-style
 }
 
 @defproc[(tree-layout? [v any/c]) boolean?]{

--- a/pict-doc/pict/scribblings/tree-layout.scrbl
+++ b/pict-doc/pict/scribblings/tree-layout.scrbl
@@ -25,11 +25,11 @@ that render them as @racket[pict]s.
   to @racket[tree-edge]. Children that are @racket[#f] correspond to
   leaf nodes that are not drawn.
   
-  The default @racket[node-pict] (used when it is @racket[#f]) is
-  @default-node-pict
+  The default @racket[node-pict] (used when @racket[node-pict] is @racket[#f])
+  is @|default-node-pict|.
 }
 
-@defproc[(tree-edge [node tree-layout?]
+@defproc[(tree-edge [node (and/c tree-layout? (not/c #f))]
                     [#:edge-color edge-color
                                   (or/c string? 
                                         (is-a?/c color%)
@@ -46,7 +46,7 @@ that render them as @racket[pict]s.
                                   'unspecified])
          tree-edge?]{
   This function specifies an edge from some parent to the given @racket[node].
-  It it intended to be used with @racket[tree-layout].
+  It it intended to be used with @racket[tree-layout], on a non-@racket[#f] node.
 
   When @racket[edge-width] is @racket['unspecified], the line width will not be
   set. This is intended to allow the line width to be set for the whole pict
@@ -63,8 +63,8 @@ that render them as @racket[pict]s.
                                        #:edge-style 'dot
                                        (tree-layout))))]
 
-  @history[#:changed "6.1.0.5" "Added an #:edge-width option"]
-  @; TODO: Add history comment re edge-style
+  @history[#:changed "1.3" @list{Added the @racket[#:edge-width] option.}
+           #:changed "1.9" @list{Added the @racket[#:edge-style] option.}]
 }
 
 @defproc[(tree-layout? [v any/c]) boolean?]{

--- a/pict-lib/pict/private/hv.rkt
+++ b/pict-lib/pict/private/hv.rkt
@@ -21,21 +21,21 @@ Computational Geometry, Theory and Applications 2 (1992)
      (match t
        [#f (blank)]
        [(tree-layout pict (list left right))
-        (define-values (left-t left-color left-width)
+        (define-values (left-t left-color left-width left-style)
           (match left
-            [#f (values #f #f #f)]
-            [(tree-edge child color width) (values child color width)]))
-        (define-values (right-t right-color right-width)
+            [#f (values #f #f #f #f)]
+            [(tree-edge child color width style) (values child color width style)]))
+        (define-values (right-t right-color right-width right-style)
           (match right
-            [#f (values #f #f #f)]
-            [(tree-edge child color width) (values child color width)]))
+            [#f (values #f #f #f #f)]
+            [(tree-edge child color width style) (values child color width style)]))
         (cond
           [(and (not left-t) (not right-t)) 
            (dot-ize pict)]
           [(not left-t) 
-           (empty-left (dot-ize pict) x-spacing right-color right-width (loop right-t (not l)))]
+           (empty-left (dot-ize pict) x-spacing right-color right-width right-style (loop right-t (not l)))]
           [(not right-t)
-           (empty-right (dot-ize pict) y-spacing left-color left-width (loop left-t (not l)))]
+           (empty-right (dot-ize pict) y-spacing left-color left-width left-style (loop left-t (not l)))]
           [else
            (define left-p (loop left-t (not l)))
            (define right-p (loop right-t (not l)))
@@ -44,7 +44,8 @@ Computational Geometry, Theory and Applications 2 (1992)
               x-spacing y-spacing
               left-p right-p))
            (pin-over
-            (add-lines main left-color right-color left-width right-width left-p right-p)
+            (add-lines main left-color right-color left-width right-width left-style right-style
+                       left-p right-p)
             (- (/ (pict-width pict) 2))
             (- (/ (pict-height pict) 2))
             pict)])]))
@@ -67,23 +68,23 @@ Computational Geometry, Theory and Applications 2 (1992)
    (ht-append (blank hgap 0) left)
    right))
 
-(define (empty-left pict hgap color width sub-tree-p)
+(define (empty-left pict hgap color width style sub-tree-p)
   (add-a-line (ht-append hgap pict sub-tree-p)
               color 
-              width
+              width style
               sub-tree-p))
   
-(define (empty-right pict vgap color width sub-tree-p)
+(define (empty-right pict vgap color width style sub-tree-p)
   (add-a-line (vl-append vgap pict sub-tree-p)
               color
-              width
+              width style
               sub-tree-p))
 
-(define (add-lines main left-color right-color left-width right-width t1 t2)
-  (add-a-line (add-a-line main left-color left-width t1)
-              right-color right-width t2))
+(define (add-lines main left-color right-color left-width right-width left-style right-style t1 t2)
+  (add-a-line (add-a-line main left-color left-width left-style t1)
+              right-color right-width right-style t2))
   
-(define (add-a-line main color width sub)
+(define (add-a-line main color width style sub)
   (define colored
     (colorize
       (pin-line (ghost main)
@@ -94,8 +95,10 @@ Computational Geometry, Theory and Applications 2 (1992)
     (if (eq? width 'unspecified)
         colored
         (linewidth width colored)))
+  (define with-linestyle
+    (if (eq? style 'unspecified) with-linewidth (linestyle style with-linewidth)))
   (cc-superimpose
-   (launder with-linewidth)
+   (launder with-linestyle)
    main))
 
 (module+ test

--- a/pict-lib/pict/private/layout.rkt
+++ b/pict-lib/pict/private/layout.rkt
@@ -12,7 +12,7 @@
 
 ;; values of this struct leak outside, so it cannot be transparent
 (struct tree-layout (pict children))
-(struct tree-edge (child edge-color edge-width))
+(struct tree-edge (child edge-color edge-width edge-style))
 
 (define _tree-layout
   (let ([constructor tree-layout])
@@ -41,8 +41,9 @@
   (let ([constructor tree-edge])
     (define (tree-edge child
                        #:edge-color [edge-color "gray"]
-                       #:edge-width [edge-width 'unspecified])
-      (constructor child edge-color edge-width))
+                       #:edge-width [edge-width 'unspecified]
+                       #:edge-style [edge-style 'unspecified])
+      (constructor child edge-color edge-width edge-style))
     tree-edge))
 
 (define (binary-tree-layout? t)
@@ -55,7 +56,7 @@
 
 (define (binary-tree-edge? e)
   (match e
-    [(tree-edge t _ _) (binary-tree-layout? t)]
+    [(tree-edge t _ _ _) (binary-tree-layout? t)]
     [#f #t]))
 
 (define (compute-spacing t given-x-spacing given-y-spacing)
@@ -75,7 +76,7 @@
           (for ([edge (in-list children)])
             (match edge
               [#f (void)]
-              [(tree-edge child edge-color _)
+              [(tree-edge child edge-color _ _)
                (loop child)]))]))
      
      (values (or given-x-spacing x-spacing)

--- a/pict-lib/pict/private/naive-layered.rkt
+++ b/pict-lib/pict/private/naive-layered.rkt
@@ -22,7 +22,7 @@
                   [#f 
                    (define b (blank))
                    (cons b b)]
-                  [(tree-edge child color _)
+                  [(tree-edge child color _ _)
                    (loop child)])))
             (define this-root (launder (ghost pict)))
             (define children-roots (map car children-pairs))
@@ -43,7 +43,7 @@
                  (define this-tree-edge (car tree-edges))
                  (match this-tree-edge
                    [#f (loop main (cdr children-roots) (cdr tree-edges))]
-                   [(tree-edge child edge-color edge-width)
+                   [(tree-edge child edge-color edge-width edge-style)
                     (define *w/line
                       (colorize
                        (launder
@@ -52,9 +52,13 @@
                                   child-root cc-find))
                        edge-color))
                     (define w/line
-                      (if (eq? edge-width 'unspecified)
-                          *w/line
-                          (linewidth edge-width *w/line)))
+                      (let ([w/width
+                             (if (eq? edge-width 'unspecified)
+                                 *w/line
+                                 (linewidth edge-width *w/line))])
+                        (if (eq? edge-style 'unspecified)
+                            w/width
+                            (linestyle edge-style w/width))))
                     (loop (cc-superimpose w/line main)
                           (cdr children-roots)
                           (cdr tree-edges))])]))])])))

--- a/pict-lib/pict/private/tidier.rkt
+++ b/pict-lib/pict/private/tidier.rkt
@@ -46,7 +46,7 @@ Vol 7, #2, March 1981
                                (* x x-spacing)
                                (* y y-spacing)
                                node-pict))
-          (define (add-edge to color width)
+          (define (add-edge to color width style)
             (define colored
               (colorize (launder (pin-line (ghost main)
                                            node-pict cc-find
@@ -56,17 +56,21 @@ Vol 7, #2, March 1981
               (if (eq? width 'unspecified)
                   colored
                   (linewidth width colored)))
-            (set! main (cc-superimpose with-linewidth main)))
+            (define with-linestyle
+              (if (eq? style 'unspecified)
+                  with-linewidth
+                  (linestyle style with-linewidth)))
+            (set! main (cc-superimpose with-linestyle main)))
           (match left-t
             [#f (void)]
-            [(tree-edge left-t left-color left-width)
+            [(tree-edge left-t left-color left-width left-style)
              (define left-pict (loop left-t left-xc (+ y 1)))
-             (add-edge left-pict left-color left-width)])
+             (add-edge left-pict left-color left-width left-style)])
           (match right-t
             [#f (void)]
-            [(tree-edge right-t right-color right-width)
+            [(tree-edge right-t right-color right-width right-style)
              (define right-pict (loop right-t right-xc (+ y 1)))
-             (add-edge right-pict right-color right-width)])
+             (add-edge right-pict right-color right-width right-style)])
           node-pict]))
      
      main]

--- a/pict-lib/pict/tree-layout.rkt
+++ b/pict-lib/pict/tree-layout.rkt
@@ -19,7 +19,7 @@
                tree-layout?)]
   [rename _tree-edge
           tree-edge
-          (->* (tree-layout?) 
+          (->* ((and/c tree-layout? (not/c #f))) 
                (#:edge-color (or/c string? 
                                    (is-a?/c color%)
                                    (list/c byte? byte? byte?))

--- a/pict-lib/pict/tree-layout.rkt
+++ b/pict-lib/pict/tree-layout.rkt
@@ -23,7 +23,12 @@
                (#:edge-color (or/c string? 
                                    (is-a?/c color%)
                                    (list/c byte? byte? byte?))
-                #:edge-width (or/c 'unspecified real? #f))
+                #:edge-width (or/c 'unspecified real? #f)
+                #:edge-style (or/c 'unspecified
+                                   'transparent 'solid 'xor 'hilite
+                                   'dot 'long-dash 'short-dash 'dot-dash
+                                   'xor-dot 'xor-long-dash 'xor-short-dash
+                                   'xor-dot-dash))
                tree-edge?)]
           
 

--- a/pict-lib/pict/tree-layout.rkt
+++ b/pict-lib/pict/tree-layout.rkt
@@ -19,7 +19,7 @@
                tree-layout?)]
   [rename _tree-edge
           tree-edge
-          (->* ((and/c tree-layout? (not/c #f))) 
+          (->* ((and/c _tree-layout? (not/c #f))) 
                (#:edge-color (or/c string? 
                                    (is-a?/c color%)
                                    (list/c byte? byte? byte?))


### PR DESCRIPTION
This PR adds an ```#:edge-style``` keyword to the ```tree-edge``` function, similar to the existing ```#:edge-width``` keyword.

I don't know what version number is appropriate to add for an ```@history``` footnote, so I've left a TODO comment in its place.