### PR TITLE
Langify and reindent modules

### DIFF
--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -1,471 +1,472 @@
-(module pict scheme/base
-  (require (rename-in "pict.rkt"
-                      [hline t:hline]
-                      [vline t:vline]
-                      [frame t:frame])
-           "convertible.rkt"
-           (rename-in "utils.rkt"
-                      [pin-line t:pin-line]
-                      [pin-arrow-line t:pin-arrow-line]
-                      [pin-arrows-line t:pin-arrows-line])
-           (only-in racket/draw dc-path% make-bitmap bitmap% bitmap-dc% color%)
-           (only-in racket/class new send make-object is-a?/c)
-           racket/contract)
+#lang scheme/base
 
-  (define (hline w h #:segment [seg #f])
-    (if seg
-        (dash-hline w h seg)
-        (t:hline w h)))
+(require (rename-in "pict.rkt"
+                    [hline t:hline]
+                    [vline t:vline]
+                    [frame t:frame])
+         "convertible.rkt"
+         (rename-in "utils.rkt"
+                    [pin-line t:pin-line]
+                    [pin-arrow-line t:pin-arrow-line]
+                    [pin-arrows-line t:pin-arrows-line])
+         (only-in racket/draw dc-path% make-bitmap bitmap% bitmap-dc% color%)
+         (only-in racket/class new send make-object is-a?/c)
+         racket/contract)
 
-  (define (vline w h #:segment [seg #f])
-    (if seg
-        (dash-vline w h seg)
-        (t:vline w h)))
+(define (hline w h #:segment [seg #f])
+  (if seg
+      (dash-hline w h seg)
+      (t:hline w h)))
 
-  (define (frame p
-                 #:color [col #f]
-                 #:line-width [lw #f]
-                 #:segment [seg #f])
-    (let* ([p (pict-convert p)]
-           [f (if seg
-                     (dash-frame (launder (ghost p)) seg)
-                     (t:frame (launder (ghost p))))]
-           [f (if col
-                  (colorize f col)
-                  f)]
-           [f (if lw 
-                  (linewidth lw f)
-                  f)])
-      (refocus (cc-superimpose p f)
-               p)))
+(define (vline w h #:segment [seg #f])
+  (if seg
+      (dash-vline w h seg)
+      (t:vline w h)))
 
-  (define (pict-path? p)
-    (or (pict-convertible? p)
-        (and (pair? p)
-             (list? p)
-             (andmap pict-convertible? p))))
+(define (frame p
+               #:color [col #f]
+               #:line-width [lw #f]
+               #:segment [seg #f])
+  (let* ([p (pict-convert p)]
+         [f (if seg
+                (dash-frame (launder (ghost p)) seg)
+                (t:frame (launder (ghost p))))]
+         [f (if col
+                (colorize f col)
+                f)]
+         [f (if lw 
+                (linewidth lw f)
+                f)])
+    (refocus (cc-superimpose p f)
+             p)))
 
-  (define (label-line label pict src-pict src-coord-fn dest-pict dest-coord-fn
-                      #:x-adjust [x-adjust 0] #:y-adjust [y-adjust 0])
-    (let-values ([(src-x src-y) (src-coord-fn pict src-pict)]
-                 [(dest-x dest-y) (dest-coord-fn pict dest-pict)])
-      (let* ([src (make-rectangular src-x src-y)]
-             [dest (make-rectangular dest-x dest-y)]
-             [adjust (make-rectangular x-adjust y-adjust)]
-             [v (- dest src)]
-             [h2 (pict-height label)])
-        ;; Ensure that the src is left of dest
-        (when (< (real-part v) 0)
-          (set! v (- v))
-          (set! src dest))
-        (let ([p (+ src
-                    ;; Move the label to sit atop the line.
-                    (/ (* h2 -i v) (magnitude v) 2)
-                    ;; Center the label in the line.
-                    (/ (- v (make-rectangular (pict-width label)
-                                              (pict-height label)))
-                       2)
-                    adjust)])
-          (pin-over
-           pict
-           (real-part p)
-           (imag-part p)
-           label)))))
+(define (pict-path? p)
+  (or (pict-convertible? p)
+      (and (pair? p)
+           (list? p)
+           (andmap pict-convertible? p))))
 
-  (define (pin-line p 
+(define (label-line label pict src-pict src-coord-fn dest-pict dest-coord-fn
+                    #:x-adjust [x-adjust 0] #:y-adjust [y-adjust 0])
+  (let-values ([(src-x src-y) (src-coord-fn pict src-pict)]
+               [(dest-x dest-y) (dest-coord-fn pict dest-pict)])
+    (let* ([src (make-rectangular src-x src-y)]
+           [dest (make-rectangular dest-x dest-y)]
+           [adjust (make-rectangular x-adjust y-adjust)]
+           [v (- dest src)]
+           [h2 (pict-height label)])
+      ;; Ensure that the src is left of dest
+      (when (< (real-part v) 0)
+        (set! v (- v))
+        (set! src dest))
+      (let ([p (+ src
+                  ;; Move the label to sit atop the line.
+                  (/ (* h2 -i v) (magnitude v) 2)
+                  ;; Center the label in the line.
+                  (/ (- v (make-rectangular (pict-width label)
+                                            (pict-height label)))
+                     2)
+                  adjust)])
+        (pin-over
+         pict
+         (real-part p)
+         (imag-part p)
+         label)))))
+
+(define (pin-line p 
+                  src src-find
+                  dest dest-find
+                  #:start-angle [sa #f] #:end-angle [ea #f]
+                  #:start-pull [sp #f] #:end-pull [ep #f]
+                  #:color [col #f]
+                  #:alpha [alpha 1.0]
+                  #:line-width [lw #f]
+                  #:under? [under? #f]
+                  #:solid? [solid? #t]
+                  #:style [style #f]
+                  #:label [label #f]
+                  #:x-adjust-label [x-adjust 0]
+                  #:y-adjust-label [y-adjust 0])
+  (define line
+    (if (not (or sa ea))
+        (finish-pin (launder (t:pin-line (ghost p)
+                                         src src-find 
+                                         dest dest-find
+                                         #:style style))
+                    p lw col alpha under?)
+        (pin-curve* #f #f p src src-find dest dest-find
+                    sa ea sp ep 0 col lw under? #t
+                    style alpha)))
+  (if label
+      (label-line label line src src-find dest dest-find
+                  #:x-adjust x-adjust #:y-adjust y-adjust)
+      line))
+
+(define (pin-arrow-line sz p 
+                        src src-find
+                        dest dest-find
+                        #:start-angle [sa #f] #:end-angle [ea #f]
+                        #:start-pull [sp #f] #:end-pull [ep #f]
+                        #:color [col #f]
+                        #:alpha [alpha 1.0]
+                        #:line-width [lw #f]
+                        #:under? [under? #f]
+                        #:solid? [solid? #t]
+                        #:style [style #f]
+                        #:hide-arrowhead? [hide-arrowhead? #f]
+                        #:label [label #f]
+                        #:x-adjust-label [x-adjust 0]
+                        #:y-adjust-label [y-adjust 0])
+  (define line
+    (if (not (or sa ea))
+        (finish-pin (launder (t:pin-arrow-line sz (ghost p)
+                                               src src-find 
+                                               dest dest-find
+                                               #f #f #f solid?
+                                               #:hide-arrowhead? hide-arrowhead?
+                                               #:style style))
+                    p lw col alpha under?)
+        (pin-curve* #f (not hide-arrowhead?) p src src-find dest dest-find
+                    sa ea sp ep sz col lw under? solid?
+                    style alpha)))
+  (if label
+      (label-line label line src src-find dest dest-find
+                  #:x-adjust x-adjust #:y-adjust y-adjust)
+      line))
+  
+(define (pin-arrows-line sz p 
+                         src src-find
+                         dest dest-find
+                         #:start-angle [sa #f] #:end-angle [ea #f]
+                         #:start-pull [sp #f] #:end-pull [ep #f]
+                         #:color [col #f]
+                         #:alpha [alpha 1.0]
+                         #:line-width [lw #f]
+                         #:under? [under? #f]
+                         #:solid? [solid? #t]
+                         #:style [style #f]
+                         #:hide-arrowhead? [hide-arrowhead? #f]
+                         #:label [label #f]
+                         #:x-adjust-label [x-adjust 0]
+                         #:y-adjust-label [y-adjust 0])
+  (define line
+    (if (not (or sa ea))
+        (finish-pin (launder (t:pin-arrows-line sz (ghost p)
+                                                src src-find 
+                                                dest dest-find
+                                                #f #f #f solid?
+                                                #:hide-arrowhead? hide-arrowhead?
+                                                #:style style))
+                    p lw col alpha under?)
+        (pin-curve* (not hide-arrowhead?) (not hide-arrowhead?)
+                    p src src-find dest dest-find
+                    sa ea sp ep sz col lw under? solid? 
+                    style alpha)))
+  (if label
+      (label-line label line src src-find dest dest-find
+                  #:x-adjust x-adjust #:y-adjust y-adjust)
+      line))
+    
+(define (pin-curve* start-arrow? end-arrow? p 
                     src src-find
                     dest dest-find
-                    #:start-angle [sa #f] #:end-angle [ea #f]
-                    #:start-pull [sp #f] #:end-pull [ep #f]
-                    #:color [col #f]
-                    #:alpha [alpha 1.0]
-                    #:line-width [lw #f]
-                    #:under? [under? #f]
-                    #:solid? [solid? #t]
-                    #:style [style #f]
-                    #:label [label #f]
-                    #:x-adjust-label [x-adjust 0]
-                    #:y-adjust-label [y-adjust 0])
-    (define line
-      (if (not (or sa ea))
-          (finish-pin (launder (t:pin-line (ghost p)
-                                           src src-find 
-                                           dest dest-find
-                                           #:style style))
-                      p lw col alpha under?)
-          (pin-curve* #f #f p src src-find dest dest-find
-                      sa ea sp ep 0 col lw under? #t
-                      style alpha)))
-    (if label
-        (label-line label line src src-find dest dest-find
-                    #:x-adjust x-adjust #:y-adjust y-adjust)
-        line))
+                    sa ea sp ep
+                    sz col lw
+                    under? solid?
+                    style alpha)
+  (let-values ([(sx0 sy0) (src-find p src)]
+               [(dx0 dy0) (dest-find p dest)])
+    (let* ([sa (or sa
+                   (atan (- sy0 dy0) (- dx0 sx0)))]
+           [ea (or ea
+                   (atan (- sy0 dy0) (- dx0 sx0)))]
+           [d (sqrt (+ (* (- dy0 sy0) (- dy0 sy0)) (* (- dx0 sx0) (- dx0 sx0))))]
+           [sp (* (or sp 1/4) d)]
+           [ep (* (or ep 1/4) d)])
+      (let ([dx (if end-arrow? (- dx0 (* sz (cos ea))) dx0)]
+            [dy (if end-arrow? (+ dy0 (* sz (sin ea))) dy0)]
+            [sx (if start-arrow? (+ sx0 (* sz (cos sa))) sx0)]
+            [sy (if start-arrow? (- sy0 (* sz (sin sa))) sy0)]
+            [path (new dc-path%)]
+            [maybe-pin-line
+             (lambda (arrow? p sx sy dx dy)
+               (if arrow?
+                   (pin-arrow-line 
+                    sz
+                    p
+                    p (lambda (a b) (values sx sy))
+                    p (lambda (a b) (values dx dy))
+                    #:line-width lw
+                    #:color col
+                    #:under? under?
+                    #:solid? solid?
+                    #:style style)
+                   p))])
+        (send path move-to sx sy)
+        (send path curve-to
+              (+ sx (* sp (cos sa)))
+              (- sy (* sp (sin sa)))
+              (- dx (* ep (cos ea)))
+              (+ dy (* ep (sin ea)))
+              dx
+              dy)
+        (maybe-pin-line 
+         start-arrow?
+         (maybe-pin-line 
+          end-arrow?
+          ((if under? pin-under pin-over)
+           p
+           0 0
+           (let* ([p (dc (lambda (dc x y)
+                           (let ([b (send dc get-brush)])
+                             (send dc set-brush "white" 'transparent)
+                             (send dc draw-path path x y)
+                             (send dc set-brush b)))
+                         0 0)]
+                  [p (if col
+                         (colorize p col)
+                         p)]
+                  [p (if (= alpha 1.0)
+                         p
+                         (cellophane p alpha))]
+                  [p (if lw
+                         (linewidth lw p)
+                         p)]
+                  [p (if style
+                         (linestyle style p)
+                         p)])
+             p))
+          dx dy dx0 dy0)
+         sx sy sx0 sy0)))))
 
-  (define (pin-arrow-line sz p 
-                          src src-find
-                          dest dest-find
-                          #:start-angle [sa #f] #:end-angle [ea #f]
-                          #:start-pull [sp #f] #:end-pull [ep #f]
-                          #:color [col #f]
-                          #:alpha [alpha 1.0]
-                          #:line-width [lw #f]
-                          #:under? [under? #f]
-                          #:solid? [solid? #t]
-                          #:style [style #f]
-                          #:hide-arrowhead? [hide-arrowhead? #f]
-                          #:label [label #f]
-                          #:x-adjust-label [x-adjust 0]
-                          #:y-adjust-label [y-adjust 0])
-    (define line
-      (if (not (or sa ea))
-          (finish-pin (launder (t:pin-arrow-line sz (ghost p)
-                                                 src src-find 
-                                                 dest dest-find
-                                                 #f #f #f solid?
-                                                 #:hide-arrowhead? hide-arrowhead?
-                                                 #:style style))
-                      p lw col alpha under?)
-          (pin-curve* #f (not hide-arrowhead?) p src src-find dest dest-find
-                      sa ea sp ep sz col lw under? solid?
-                      style alpha)))
-    (if label
-        (label-line label line src src-find dest dest-find
-                    #:x-adjust x-adjust #:y-adjust y-adjust)
-        line))
+
+(define (finish-pin l p lw col alpha under?)
+  (let* ([l (if lw
+                (linewidth lw l)
+                l)]
+         [l (if col
+                (colorize l col)
+                l)]
+         [l (if (= alpha 1.0)
+                l
+                (cellophane l alpha))])
+    (if under?
+        (cc-superimpose l p)
+        (cc-superimpose p l))))
+
+(define fish
+  (let ([standard-fish
+         (lambda (w h 
+                    #:direction [direction 'left]
+                    #:color [color "blue"]
+                    #:eye-color [eye-color "black"]
+                    #:open-mouth [open-mouth #f])
+           (standard-fish w h direction color eye-color open-mouth))])
+    standard-fish))
+
+(define (pict->bitmap p [smoothing 'aligned]
+                      #:make-bitmap [make-bitmap make-bitmap])
+  (define w (pict-width p))
+  (define h (pict-height p))
+  (define bm (make-bitmap (max 1 (inexact->exact (ceiling w)))
+                          (max 1 (inexact->exact (ceiling h)))))
+  (unless (send bm ok?)
+    (error 'pict->bitmap
+           (string-append "bitmap creation failed\n"
+                          "  possible reason: out of memory\n"
+                          "  pict width: ~a\n"
+                          "  pict height: ~a")
+           w
+           h))
+  (define dc (make-object bitmap-dc% bm))
+  (send dc set-smoothing smoothing)
+  (draw-pict p dc 0 0)
+  bm)
   
-    (define (pin-arrows-line sz p 
-                             src src-find
-                             dest dest-find
-                             #:start-angle [sa #f] #:end-angle [ea #f]
-                             #:start-pull [sp #f] #:end-pull [ep #f]
-                             #:color [col #f]
-                             #:alpha [alpha 1.0]
-                             #:line-width [lw #f]
-                             #:under? [under? #f]
-                             #:solid? [solid? #t]
-                             #:style [style #f]
-                             #:hide-arrowhead? [hide-arrowhead? #f]
-                             #:label [label #f]
-                             #:x-adjust-label [x-adjust 0]
-                             #:y-adjust-label [y-adjust 0])
-      (define line
-        (if (not (or sa ea))
-            (finish-pin (launder (t:pin-arrows-line sz (ghost p)
-                                                    src src-find 
-                                                    dest dest-find
-                                                    #f #f #f solid?
-                                                    #:hide-arrowhead? hide-arrowhead?
-                                                    #:style style))
-                        p lw col alpha under?)
-            (pin-curve* (not hide-arrowhead?) (not hide-arrowhead?)
-                        p src src-find dest dest-find
-                        sa ea sp ep sz col lw under? solid? 
-                        style alpha)))
-      (if label
-          (label-line label line src src-find dest dest-find
-                      #:x-adjust x-adjust #:y-adjust y-adjust)
-          line))
-    
-  (define (pin-curve* start-arrow? end-arrow? p 
-                      src src-find
-                      dest dest-find
-                      sa ea sp ep
-                      sz col lw
-                      under? solid?
-                      style alpha)
-    (let-values ([(sx0 sy0) (src-find p src)]
-                 [(dx0 dy0) (dest-find p dest)])
-      (let* ([sa (or sa
-                     (atan (- sy0 dy0) (- dx0 sx0)))]
-             [ea (or ea
-                     (atan (- sy0 dy0) (- dx0 sx0)))]
-             [d (sqrt (+ (* (- dy0 sy0) (- dy0 sy0)) (* (- dx0 sx0) (- dx0 sx0))))]
-             [sp (* (or sp 1/4) d)]
-             [ep (* (or ep 1/4) d)])
-        (let ([dx (if end-arrow? (- dx0 (* sz (cos ea))) dx0)]
-              [dy (if end-arrow? (+ dy0 (* sz (sin ea))) dy0)]
-              [sx (if start-arrow? (+ sx0 (* sz (cos sa))) sx0)]
-              [sy (if start-arrow? (- sy0 (* sz (sin sa))) sy0)]
-              [path (new dc-path%)]
-              [maybe-pin-line
-               (lambda (arrow? p sx sy dx dy)
-                 (if arrow?
-                     (pin-arrow-line 
-                      sz
-                      p
-                      p (lambda (a b) (values sx sy))
-                      p (lambda (a b) (values dx dy))
-                      #:line-width lw
-                      #:color col
-                      #:under? under?
-                      #:solid? solid?
-                      #:style style)
-                     p))])
-          (send path move-to sx sy)
-          (send path curve-to
-                (+ sx (* sp (cos sa)))
-                (- sy (* sp (sin sa)))
-                (- dx (* ep (cos ea)))
-                (+ dy (* ep (sin ea)))
-                dx
-                dy)
-          (maybe-pin-line 
-           start-arrow?
-           (maybe-pin-line 
-            end-arrow?
-            ((if under? pin-under pin-over)
-             p
-             0 0
-             (let* ([p (dc (lambda (dc x y)
-                             (let ([b (send dc get-brush)])
-                               (send dc set-brush "white" 'transparent)
-                               (send dc draw-path path x y)
-                               (send dc set-brush b)))
-                           0 0)]
-                    [p (if col
-                           (colorize p col)
-                           p)]
-                    [p (if (= alpha 1.0)
-                           p
-                           (cellophane p alpha))]
-                    [p (if lw
-                           (linewidth lw p)
-                           p)]
-                    [p (if style
-                           (linestyle style p)
-                           p)])
-               p))
-            dx dy dx0 dy0)
-           sx sy sx0 sy0)))))
-
-
-  (define (finish-pin l p lw col alpha under?)
-    (let* ([l (if lw
-                  (linewidth lw l)
-                  l)]
-           [l (if col
-                  (colorize l col)
-                  l)]
-           [l (if (= alpha 1.0)
-                  l
-                  (cellophane l alpha))])
-      (if under?
-          (cc-superimpose l p)
-          (cc-superimpose p l))))
-
-  (define fish
-    (let ([standard-fish
-           (lambda (w h 
-                      #:direction [direction 'left]
-                      #:color [color "blue"]
-                      #:eye-color [eye-color "black"]
-                      #:open-mouth [open-mouth #f])
-             (standard-fish w h direction color eye-color open-mouth))])
-      standard-fish))
-
-  (define (pict->bitmap p [smoothing 'aligned]
-                        #:make-bitmap [make-bitmap make-bitmap])
-    (define w (pict-width p))
-    (define h (pict-height p))
-    (define bm (make-bitmap (max 1 (inexact->exact (ceiling w)))
-                            (max 1 (inexact->exact (ceiling h)))))
-    (unless (send bm ok?)
-      (error 'pict->bitmap
-             (string-append "bitmap creation failed\n"
-                            "  possible reason: out of memory\n"
-                            "  pict width: ~a\n"
-                            "  pict height: ~a")
-             w
-             h))
-    (define dc (make-object bitmap-dc% bm))
-    (send dc set-smoothing smoothing)
-    (draw-pict p dc 0 0)
-    bm)
+(define (pict->argb-pixels p [smoothing 'aligned])
+  (define bm (pict->bitmap p smoothing))
+  (define w (send bm get-width)) 
+  (define h (send bm get-height))
+  (define bytes (make-bytes (* w h 4)))
+  (send bm get-argb-pixels 0 0 w h bytes)
+  bytes)
   
-  (define (pict->argb-pixels p [smoothing 'aligned])
-    (define bm (pict->bitmap p smoothing))
-    (define w (send bm get-width)) 
-    (define h (send bm get-height))
-    (define bytes (make-bytes (* w h 4)))
-    (send bm get-argb-pixels 0 0 w h bytes)
-    bytes)
-  
-  (define (argb-pixels->pict b w)
-    (define h (/ (bytes-length b) w 4))
-    (define bm (make-bitmap w (/ (bytes-length b) w 4)))
-    (send bm set-argb-pixels 0 0 w h b)
-    (bitmap bm))
+(define (argb-pixels->pict b w)
+  (define h (/ (bytes-length b) w 4))
+  (define bm (make-bitmap w (/ (bytes-length b) w 4)))
+  (send bm set-argb-pixels 0 0 w h b)
+  (bitmap bm))
 
-  (define (freeze p)
-    (define p* (pict-convert p))
-    (define frozen (bitmap (pict->bitmap p*)))
-    (struct-copy pict p* [draw (pict-draw frozen)]))
+(define (freeze p)
+  (define p* (pict-convert p))
+  (define frozen (bitmap (pict->bitmap p*)))
+  (struct-copy pict p* [draw (pict-draw frozen)]))
 
-  (provide hline vline
-           frame
-           pict-path?
-           pin-line pin-arrow-line pin-arrows-line
-           freeze
+(provide hline vline
+         frame
+         pict-path?
+         pin-line pin-arrow-line pin-arrows-line
+         freeze
 
 
-           dc-for-text-size
-           convert-bounds-padding
-           show-pict
-           current-expected-text-scale
-           dc
-           linewidth
-           linestyle
+         dc-for-text-size
+         convert-bounds-padding
+         show-pict
+         current-expected-text-scale
+         dc
+         linewidth
+         linestyle
 
-           draw-pict
-           make-pict-drawer
+         draw-pict
+         make-pict-drawer
 
-           (contract-out
-            [text (->* (string?)
-                       (text-style/c 
-                        (and/c (between/c 1 1024) integer?)
-                        number?)
-                       pict?)])
+         (contract-out
+          [text (->* (string?)
+                     (text-style/c 
+                      (and/c (between/c 1 1024) integer?)
+                      number?)
+                     pict?)])
 
-           text-style/c
+         text-style/c
 
-           (struct-out pict)
-           (struct-out child)
+         (struct-out pict)
+         (struct-out child)
 
-           black-and-white
+         black-and-white
 
-           lt-find
-           lc-find
-           lb-find
-           ltl-find
-           lbl-find
-           ct-find
-           cc-find
-           cb-find
-           ctl-find
-           cbl-find
-           rt-find
-           rc-find
-           rb-find
-           rtl-find
-           rbl-find
+         lt-find
+         lc-find
+         lb-find
+         ltl-find
+         lbl-find
+         ct-find
+         cc-find
+         cb-find
+         ctl-find
+         cbl-find
+         rt-find
+         rc-find
+         rb-find
+         rtl-find
+         rbl-find
 
 
-           launder  ; pict -> pict
+         launder  ; pict -> pict
 
-           blank        ; -> pict
-           ;; w h -> pict
-           ;; w h d -> pict
+         blank        ; -> pict
+         ;; w h -> pict
+         ;; w h d -> pict
 
-           clip-descent   ; pict -> pict
-           clip-ascent    ; pict -> pict
-           baseless       ; pict -> pict
-           inset          ; pict i -> pict
-           ; pict hi vi -> pict
-           ; pict l t r b -> pict
-           refocus        ; pict pict -> pict
-           panorama       ; pict -> pict
+         clip-descent   ; pict -> pict
+         clip-ascent    ; pict -> pict
+         baseless       ; pict -> pict
+         inset          ; pict i -> pict
+         ; pict hi vi -> pict
+         ; pict l t r b -> pict
+         refocus        ; pict pict -> pict
+         panorama       ; pict -> pict
 
-           use-last       ; pict pict -> pict
-           use-last*      ; pict pict -> pict
+         use-last       ; pict pict -> pict
+         use-last*      ; pict pict -> pict
 
-           hline        ; w h -> pict
-           vline        ; w h -> pict
+         hline        ; w h -> pict
+         vline        ; w h -> pict
          
-           frame        ; pict -> pict
+         frame        ; pict -> pict
          
          
          
-           ghost        ; pict -> pict
+         ghost        ; pict -> pict
 
          
-           vl-append    ; d pict ... -> pict ; d units between each picture
-           vc-append
-           vr-append
-           ht-append
-           hc-append
-           hb-append
-           htl-append       ; align bottoms of ascents
-           hbl-append       ; align tops of descents (normal text alignment)
+         vl-append    ; d pict ... -> pict ; d units between each picture
+         vc-append
+         vr-append
+         ht-append
+         hc-append
+         hb-append
+         htl-append       ; align bottoms of ascents
+         hbl-append       ; align tops of descents (normal text alignment)
 
-           lt-superimpose ; pict ... -> pict
-           lb-superimpose
-           lc-superimpose
-           ltl-superimpose
-           lbl-superimpose
-           rt-superimpose
-           rb-superimpose
-           rc-superimpose
-           rtl-superimpose
-           rbl-superimpose
-           ct-superimpose
-           cb-superimpose
-           cc-superimpose
-           ctl-superimpose
-           cbl-superimpose
+         lt-superimpose ; pict ... -> pict
+         lb-superimpose
+         lc-superimpose
+         ltl-superimpose
+         lbl-superimpose
+         rt-superimpose
+         rb-superimpose
+         rc-superimpose
+         rtl-superimpose
+         rbl-superimpose
+         ct-superimpose
+         cb-superimpose
+         cc-superimpose
+         ctl-superimpose
+         cbl-superimpose
 
-           table ; ncols pict-list col-aligns row-aligns col-seps row-seps -> pict
+         table ; ncols pict-list col-aligns row-aligns col-seps row-seps -> pict
 
-           colorize ; pict color-string -> pict
+         colorize ; pict color-string -> pict
 
-           pin-over
-           pin-under
-           drop-below-ascent
-           lift-above-baseline
+         pin-over
+         pin-under
+         drop-below-ascent
+         lift-above-baseline
 
-           (except-out (all-from-out "utils.rkt")
+         (except-out (all-from-out "utils.rkt")
                    
-                       color-frame color-dash-frame
-                       round-frame color-round-frame
+                     color-frame color-dash-frame
+                     round-frame color-round-frame
     
-                       cons-colorized-picture
-                       arrow-line
-                       arrows-line
+                     cons-colorized-picture
+                     arrow-line
+                     arrows-line
 
-                       add-line
-                       add-arrow-line
-                       add-arrows-line
+                     add-line
+                     add-arrow-line
+                     add-arrows-line
 
-                       explode-star
+                     explode-star
 
-                       cloud
-                       file-icon
-                       standard-fish
-                       jack-o-lantern
-                       angel-wing
-                       desktop-machine
-                       thermometer
+                     cloud
+                     file-icon
+                     standard-fish
+                     jack-o-lantern
+                     angel-wing
+                     desktop-machine
+                     thermometer
 
-                       find-pen find-brush)
-           (contract-out
-            [cloud (->* [real? real?]
-                        [(or/c string? (is-a?/c color%))
-                         #:style (listof (or/c 'square 'nw 'ne 'sw 'se 'wide))]
-                       pict?)]
-            [file-icon (->* [real? real? any/c] [any/c] pict?)]
-            [rename fish standard-fish (->* [real? real?]
-                                            [#:direction (or/c 'left 'right)
-                                             #:color (or/c string? (is-a?/c color%))
-                                             #:eye-color (or/c string? (is-a?/c color%) #f)
-                                             #:open-mouth (or/c boolean? (between/c 0 1))]
-                                            pict?)]
-            [jack-o-lantern (->* [real?]
-                                 [(or/c string? (is-a?/c color%))
-                                  (or/c string? (is-a?/c color%))
-                                  (or/c string? (is-a?/c color%))]
-                                 pict?)]
-            [angel-wing (-> real? real? any/c pict?)]
-            [desktop-machine (->* [real?] [(listof symbol?)] pict?)]
-            [thermometer (->* []
-                              [#:height-% (between/c 0 1)
-                               #:color-% (between/c 0 1)
-                               #:ticks exact-nonnegative-integer?
-                               #:start-color (or/c string? (is-a?/c color%))
-                               #:end-color (or/c string? (is-a?/c color%))
-                               #:top-circle-diameter (>/c 0)
-                               #:bottom-circle-diameter (>/c 0)
-                               #:stem-height (>/c 0)
-                               #:mercury-inset (>/c 0)]
-                              pict?)])
-           pict->bitmap
-           pict->argb-pixels
-           argb-pixels->pict))
+                     find-pen find-brush)
+         (contract-out
+          [cloud (->* [real? real?]
+                      [(or/c string? (is-a?/c color%))
+                       #:style (listof (or/c 'square 'nw 'ne 'sw 'se 'wide))]
+                      pict?)]
+          [file-icon (->* [real? real? any/c] [any/c] pict?)]
+          [rename fish standard-fish (->* [real? real?]
+                                          [#:direction (or/c 'left 'right)
+                                           #:color (or/c string? (is-a?/c color%))
+                                           #:eye-color (or/c string? (is-a?/c color%) #f)
+                                           #:open-mouth (or/c boolean? (between/c 0 1))]
+                                          pict?)]
+          [jack-o-lantern (->* [real?]
+                               [(or/c string? (is-a?/c color%))
+                                (or/c string? (is-a?/c color%))
+                                (or/c string? (is-a?/c color%))]
+                               pict?)]
+          [angel-wing (-> real? real? any/c pict?)]
+          [desktop-machine (->* [real?] [(listof symbol?)] pict?)]
+          [thermometer (->* []
+                            [#:height-% (between/c 0 1)
+                             #:color-% (between/c 0 1)
+                             #:ticks exact-nonnegative-integer?
+                             #:start-color (or/c string? (is-a?/c color%))
+                             #:end-color (or/c string? (is-a?/c color%))
+                             #:top-circle-diameter (>/c 0)
+                             #:bottom-circle-diameter (>/c 0)
+                             #:stem-height (>/c 0)
+                             #:mercury-inset (>/c 0)]
+                            pict?)])
+         pict->bitmap
+         pict->argb-pixels
+         argb-pixels->pict)

--- a/pict-lib/texpict/balloon.rkt
+++ b/pict-lib/texpict/balloon.rkt
@@ -1,186 +1,187 @@
-(module balloon racket/base
-  (require pict/private/pict
-           pict/private/utils
-           racket/draw
-           mzlib/class
-           mzlib/math)
+#lang racket/base
 
-  (provide wrap-balloon pip-wrap-balloon
-           place-balloon
-           pin-balloon
-           (rename-out [mk-balloon balloon])
-           make-balloon
-           balloon?
-           balloon-pict
-           balloon-point-x
-           balloon-point-y
-           balloon-color
-           balloon-enable-3d)
+(require pict/private/pict
+         pict/private/utils
+         racket/draw
+         mzlib/class
+         mzlib/math)
 
-  (define-struct balloon (pict point-x point-y))
+(provide wrap-balloon pip-wrap-balloon
+         place-balloon
+         pin-balloon
+         (rename-out [mk-balloon balloon])
+         make-balloon
+         balloon?
+         balloon-pict
+         balloon-point-x
+         balloon-point-y
+         balloon-color
+         balloon-enable-3d)
+
+(define-struct balloon (pict point-x point-y))
     
-  (define no-pen (find-pen "white" 1 'transparent))
-  (define no-brush (find-brush "white" 'transparent))
-  (define black-pen (find-pen "black"))
+(define no-pen (find-pen "white" 1 'transparent))
+(define no-brush (find-brush "white" 'transparent))
+(define black-pen (find-pen "black"))
 
-  (define balloon-enable-3d (make-parameter #t (lambda (x) (and x #t))))
+(define balloon-enable-3d (make-parameter #t (lambda (x) (and x #t))))
 
-  (define (series dc steps start-c end-c f pen? brush?)
-    (if (balloon-enable-3d)
-        (color-series dc steps #e0.5 start-c end-c f pen? brush?)
-        (color-series dc 0 0 start-c end-c f pen? brush?)))
+(define (series dc steps start-c end-c f pen? brush?)
+  (if (balloon-enable-3d)
+      (color-series dc steps #e0.5 start-c end-c f pen? brush?)
+      (color-series dc 0 0 start-c end-c f pen? brush?)))
     
-  (define (mk-balloon w h corner-radius spike-pos dx dy
-                      [color balloon-color])
-    (let ([dw (if (< corner-radius 1)
-                  (* corner-radius w)
-                  corner-radius)]
-          [dh (if (< corner-radius 1)
-                  (* corner-radius h)
-                  corner-radius)]
-          [dxbig (lambda (v) (if (> (abs dx) (abs dy))
-                                 v
-                                 0))]
-          [dybig (lambda (v) (if (<= (abs dx) (abs dy))
-                                 v
-                                 0))])
-      (let-values ([(bx0 by0 bx1 by1 x0 y0 x1 y1 xc yc mx0 mx1 my0 my1 mfx mfy)
-                    (case spike-pos
-                      [(w) (values -1 -0.5 -1 0.5
-                                   1 (/ (- h dh) 2)
-                                   1 (/ (+ h dh) 2)
-                                   1 (/ h 2)
-                                   0.5 1 0.5 -1
-                                   1 0)]
-                      [(nw) (values 0 0 0 0
-                                    0 dh
-                                    dw 0
-                                    0 0
-                                    1 -0.5 -1 0.5
-                                    (dxbig 1) (dybig 1))]
-                      [(e) (values 1 -0.5 1 0.5
-                                   (sub1 w) (/ (- h dh) 2)
-                                   (sub1 w) (/ (+ h dh) 2)
-                                   (sub1 w) (/ h 2)
-                                   -1 -1 1 -1
-                                   -1 0)]
-                      [(ne) (values 0 0 0 0 
-                                    (- w dw) 0
-                                    w dh
-                                    w 0
-                                    0.5 -1 0.5 -1
-                                    (dxbig -1) (dybig 1))]
-                      [(s) (values -0.5 1 0.5 1
-                                   (/ (- w dw) 2) (sub1 h)
-                                   (/ (+ w dw) 2) (sub1 h)
-                                   (/ w 2) (sub1 h)
-                                   1 -1 -1 -1
-                                   0 -1)]
-                      [(n) (values -0.5 -1 0.5 -1
-                                   (/ (- w dw) 2) 1
-                                   (/ (+ w dw) 2) 1
-                                   (/ w 2) 1
-                                   1 -1 1 1
-                                   0 1)]
-                      [(sw) (values 0 0 0 0
-                                    0 (- (sub1 h) dh)
-                                    dw (sub1 h)
-                                    0 (sub1 h)
-                                    0.5 -1 0.5 -1
-                                    (dxbig 1) (dybig -1))]
-                      [(se) (values 0 1 0 1
-                                    (- w dw) (sub1 h)
-                                    w (- (sub1 h) dh)
-                                    w (sub1 h)
-                                    0.5 -1 -1 0.5
-                                    (dxbig -1) (dybig -1))])])
-        (let ([xf (+ xc dx)]
-              [yf (+ yc dy)]
-              [dark-color (scale-color #e0.6 color)])
-          (make-balloon
-           (dc (lambda (dc x y)
-                 (let ([b (send dc get-brush)]
-                       [p (send dc get-pen)]
-                       [draw-once
-                        (lambda (i rr?)
-                          (when rr?
-			    (send dc draw-rounded-rectangle 
-                                  (+ x (/ i 2)) (+ y (/ i 2))
-                                  (- w i) (- h i)
-                                  (if (and (< (* 2 corner-radius) (- w i))
-					   (< (* 2 corner-radius) (- h i)))
-				      corner-radius
-				      (/ (min (- w i) (- h i)) 2)))
-                            (let ([p (send dc get-pen)])
-                              (send dc set-pen no-pen)
-                              (send dc draw-polygon (list (make-object point% (+ x0 (* i mx0)) (+ y0 (* i my0)))
-                                                          (make-object point% (+ xf (* i mfx)) (+ yf (* i mfy)))
-                                                          (make-object point% (+ x1 (* i mx1)) (+ y1 (* i my1))))
-                                    x y)
-                              (send dc set-pen p)))
-                          (send dc draw-line (+ x x0 bx0 (* i mx0)) (+ y y0 by0 (* i my0)) 
-                                (+ x xf (* i mfx)) (+ y yf (* i mfy)))
-                          (send dc draw-line (+ x x1 bx1 (* i mx1)) (+ y y1 by1 (* i my1))
-                                (+ x xf (* i mfx)) (+ y yf (* i mfy))))])
-                   (series dc 5
-                           dark-color
-                           (if (string? color) (make-object color% color) color)
-                           (lambda (i) (draw-once i #t))
-                           #t #t)
-                   (when (balloon-enable-3d)
-                     (send dc set-brush no-brush)
-                     (send dc set-pen (find-pen dark-color 0.5))
-                     (draw-once 0 #f))
+(define (mk-balloon w h corner-radius spike-pos dx dy
+                    [color balloon-color])
+  (let ([dw (if (< corner-radius 1)
+                (* corner-radius w)
+                corner-radius)]
+        [dh (if (< corner-radius 1)
+                (* corner-radius h)
+                corner-radius)]
+        [dxbig (lambda (v) (if (> (abs dx) (abs dy))
+                               v
+                               0))]
+        [dybig (lambda (v) (if (<= (abs dx) (abs dy))
+                               v
+                               0))])
+    (let-values ([(bx0 by0 bx1 by1 x0 y0 x1 y1 xc yc mx0 mx1 my0 my1 mfx mfy)
+                  (case spike-pos
+                    [(w) (values -1 -0.5 -1 0.5
+                                 1 (/ (- h dh) 2)
+                                 1 (/ (+ h dh) 2)
+                                 1 (/ h 2)
+                                 0.5 1 0.5 -1
+                                 1 0)]
+                    [(nw) (values 0 0 0 0
+                                  0 dh
+                                  dw 0
+                                  0 0
+                                  1 -0.5 -1 0.5
+                                  (dxbig 1) (dybig 1))]
+                    [(e) (values 1 -0.5 1 0.5
+                                 (sub1 w) (/ (- h dh) 2)
+                                 (sub1 w) (/ (+ h dh) 2)
+                                 (sub1 w) (/ h 2)
+                                 -1 -1 1 -1
+                                 -1 0)]
+                    [(ne) (values 0 0 0 0 
+                                  (- w dw) 0
+                                  w dh
+                                  w 0
+                                  0.5 -1 0.5 -1
+                                  (dxbig -1) (dybig 1))]
+                    [(s) (values -0.5 1 0.5 1
+                                 (/ (- w dw) 2) (sub1 h)
+                                 (/ (+ w dw) 2) (sub1 h)
+                                 (/ w 2) (sub1 h)
+                                 1 -1 -1 -1
+                                 0 -1)]
+                    [(n) (values -0.5 -1 0.5 -1
+                                 (/ (- w dw) 2) 1
+                                 (/ (+ w dw) 2) 1
+                                 (/ w 2) 1
+                                 1 -1 1 1
+                                 0 1)]
+                    [(sw) (values 0 0 0 0
+                                  0 (- (sub1 h) dh)
+                                  dw (sub1 h)
+                                  0 (sub1 h)
+                                  0.5 -1 0.5 -1
+                                  (dxbig 1) (dybig -1))]
+                    [(se) (values 0 1 0 1
+                                  (- w dw) (sub1 h)
+                                  w (- (sub1 h) dh)
+                                  w (sub1 h)
+                                  0.5 -1 -1 0.5
+                                  (dxbig -1) (dybig -1))])])
+      (let ([xf (+ xc dx)]
+            [yf (+ yc dy)]
+            [dark-color (scale-color #e0.6 color)])
+        (make-balloon
+         (dc (lambda (dc x y)
+               (let ([b (send dc get-brush)]
+                     [p (send dc get-pen)]
+                     [draw-once
+                      (lambda (i rr?)
+                        (when rr?
+                          (send dc draw-rounded-rectangle 
+                                (+ x (/ i 2)) (+ y (/ i 2))
+                                (- w i) (- h i)
+                                (if (and (< (* 2 corner-radius) (- w i))
+                                         (< (* 2 corner-radius) (- h i)))
+                                    corner-radius
+                                    (/ (min (- w i) (- h i)) 2)))
+                          (let ([p (send dc get-pen)])
+                            (send dc set-pen no-pen)
+                            (send dc draw-polygon (list (make-object point% (+ x0 (* i mx0)) (+ y0 (* i my0)))
+                                                        (make-object point% (+ xf (* i mfx)) (+ yf (* i mfy)))
+                                                        (make-object point% (+ x1 (* i mx1)) (+ y1 (* i my1))))
+                                  x y)
+                            (send dc set-pen p)))
+                        (send dc draw-line (+ x x0 bx0 (* i mx0)) (+ y y0 by0 (* i my0)) 
+                              (+ x xf (* i mfx)) (+ y yf (* i mfy)))
+                        (send dc draw-line (+ x x1 bx1 (* i mx1)) (+ y y1 by1 (* i my1))
+                              (+ x xf (* i mfx)) (+ y yf (* i mfy))))])
+                 (series dc 5
+                         dark-color
+                         (if (string? color) (make-object color% color) color)
+                         (lambda (i) (draw-once i #t))
+                         #t #t)
+                 (when (balloon-enable-3d)
+                   (send dc set-brush no-brush)
+                   (send dc set-pen (find-pen dark-color 0.5))
+                   (draw-once 0 #f))
                    
-                   (send dc set-pen p)
-                   (send dc set-brush b)))
-               w h 0 0)
-           xf yf)))))
+                 (send dc set-pen p)
+                 (send dc set-brush b)))
+             w h 0 0)
+         xf yf)))))
 
-  (define balloon-color (make-object color% 255 255 170))
+(define balloon-color (make-object color% 255 255 170))
   
-  (define corner-size 32)
+(define corner-size 32)
 
-  (define wrap-balloon
-    (lambda (p corner dx dy [color balloon-color] [c-rad corner-size] 
-               #:factor [factor 1])
-      (let ([b (mk-balloon (+ (pict-width p) (* 2 c-rad))
-			   (+ (pict-height p) c-rad)
-			   c-rad
-			   corner dx dy
-			   color)])
-	(make-balloon
-         (scale (cc-superimpose
-                 (balloon-pict b)
-                 p)
-                factor)
-	 (* factor (balloon-point-x b))
-	 (* factor (balloon-point-y b))))))
+(define wrap-balloon
+  (lambda (p corner dx dy [color balloon-color] [c-rad corner-size] 
+             #:factor [factor 1])
+    (let ([b (mk-balloon (+ (pict-width p) (* 2 c-rad))
+                         (+ (pict-height p) c-rad)
+                         c-rad
+                         corner dx dy
+                         color)])
+      (make-balloon
+       (scale (cc-superimpose
+               (balloon-pict b)
+               p)
+              factor)
+       (* factor (balloon-point-x b))
+       (* factor (balloon-point-y b))))))
 
-  (define pip-wrap-balloon
-    (lambda (p corner dx dy [color balloon-color] [c-rad corner-size]
-               #:factor [factor 1])
-      (pin-balloon (wrap-balloon p corner dx dy color c-rad #:factor factor) (blank 0) 0 0)))
+(define pip-wrap-balloon
+  (lambda (p corner dx dy [color balloon-color] [c-rad corner-size]
+             #:factor [factor 1])
+    (pin-balloon (wrap-balloon p corner dx dy color c-rad #:factor factor) (blank 0) 0 0)))
   
-  (define (do-place-balloon flip-proc? balloon p to find-to)
-    (let-values ([(x y) (if (and (number? to) 
-				 (number? find-to)) 
-			    (values to (- (pict-height p)
-					  find-to))
-			    (if flip-proc?
-				(let-values ([(x y) (find-to p to)])
-				  (values x (- (pict-height p) y)))
-				(find-to p to)))])
-      (cons-picture
-       p
-       `((place ,(- x (balloon-point-x balloon))
-                ,(- y  ; up-side down!
-                    (- (pict-height (balloon-pict balloon))
-                       (balloon-point-y balloon)))
-                ,(balloon-pict balloon))))))
+(define (do-place-balloon flip-proc? balloon p to find-to)
+  (let-values ([(x y) (if (and (number? to) 
+                               (number? find-to)) 
+                          (values to (- (pict-height p)
+                                        find-to))
+                          (if flip-proc?
+                              (let-values ([(x y) (find-to p to)])
+                                (values x (- (pict-height p) y)))
+                              (find-to p to)))])
+    (cons-picture
+     p
+     `((place ,(- x (balloon-point-x balloon))
+              ,(- y  ; up-side down!
+                  (- (pict-height (balloon-pict balloon))
+                     (balloon-point-y balloon)))
+              ,(balloon-pict balloon))))))
 
-  (define (place-balloon balloon p to find-to)
-    (do-place-balloon #f balloon p to find-to))
+(define (place-balloon balloon p to find-to)
+  (do-place-balloon #f balloon p to find-to))
 
-  (define (pin-balloon balloon p to find-to)
-    (do-place-balloon #t balloon p to find-to)))
+(define (pin-balloon balloon p to find-to)
+  (do-place-balloon #t balloon p to find-to))

--- a/pict-lib/texpict/code.rkt
+++ b/pict-lib/texpict/code.rkt
@@ -1,727 +1,728 @@
-(module code racket/base
-  (require pict/private/pict
-           (prefix-in r: racket/base)
-           mzlib/class
-           mzlib/list
-           (only-in scheme/list last)
-           racket/draw
-           mzlib/unit
-           (for-syntax racket/base)
-           (only-in mzscheme make-namespace))
+#lang racket/base
 
-  (provide define-code code^ code-params^ code@
-           (for-syntax prop:code-transformer
-                       code-transformer?
-                       make-code-transformer))
+(require pict/private/pict
+         (prefix-in r: racket/base)
+         mzlib/class
+         mzlib/list
+         (only-in scheme/list last)
+         racket/draw
+         mzlib/unit
+         (for-syntax racket/base)
+         (only-in mzscheme make-namespace))
 
-  (define (to-code-pict p extension)
-    (use-last* p extension))
+(provide define-code code^ code-params^ code@
+         (for-syntax prop:code-transformer
+                     code-transformer?
+                     make-code-transformer))
 
-  (define (code-pict? p)
-    (and (pict-last p) #t))
+(define (to-code-pict p extension)
+  (use-last* p extension))
 
-  (define (code-pict-bottom-line p)
-    (single-pict (pict-last p)))
+(define (code-pict? p)
+  (and (pict-last p) #t))
 
-  (define (single-pict p)
-    (if (list? p)
-        (last p)
-        p))
+(define (code-pict-bottom-line p)
+  (single-pict (pict-last p)))
 
-  (define (make-code-append htl-append)
-    (case-lambda
-     [(a b) (let ([a-last (pict-last a)])
-              (if a-last
-                  (let* ([a-dup (launder (ghost (single-pict a-last)))]
-                         [extension (htl-append a-dup b)])
-                    (let ([p (let-values ([(x y) (lt-find a a-last)]
-                                          [(dx dy) (lt-find extension a-dup)])
-                               (let ([ex (- x dx)]
-                                     [ey (- y dy)])
-                                 (if (negative? ey)
-                                     (lt-superimpose
-                                      (inset a 0 (- ey) 0 0)
-                                      (inset extension ex 0 0 0))
-                                     (lt-superimpose
-                                      a
-                                      (inset extension ex ey 0 0)))))])
-                      (use-last* p b)))
-                  (htl-append a b)))]
-     [(a) a]
-     [(a . rest)
-      ((make-code-append htl-append)
-       a
-       (apply (make-code-append htl-append) rest))]))
+(define (single-pict p)
+  (if (list? p)
+      (last p)
+      p))
 
-  (define code-htl-append (make-code-append htl-append))
-  (define code-hbl-append (make-code-append hbl-append))
+(define (make-code-append htl-append)
+  (case-lambda
+    [(a b) (let ([a-last (pict-last a)])
+             (if a-last
+                 (let* ([a-dup (launder (ghost (single-pict a-last)))]
+                        [extension (htl-append a-dup b)])
+                   (let ([p (let-values ([(x y) (lt-find a a-last)]
+                                         [(dx dy) (lt-find extension a-dup)])
+                              (let ([ex (- x dx)]
+                                    [ey (- y dy)])
+                                (if (negative? ey)
+                                    (lt-superimpose
+                                     (inset a 0 (- ey) 0 0)
+                                     (inset extension ex 0 0 0))
+                                    (lt-superimpose
+                                     a
+                                     (inset extension ex ey 0 0)))))])
+                     (use-last* p b)))
+                 (htl-append a b)))]
+    [(a) a]
+    [(a . rest)
+     ((make-code-append htl-append)
+      a
+      (apply (make-code-append htl-append) rest))]))
 
-  (define code-vl-append
-    (case-lambda
-     [(sep a b) (to-code-pict (vl-append sep a b) b)]
-     [(sep a) a]
-     [(sep a . rest)
-      (code-vl-append sep a (apply code-vl-append sep rest))]))
+(define code-htl-append (make-code-append htl-append))
+(define code-hbl-append (make-code-append hbl-append))
 
-  (begin-for-syntax
-   (define-values (prop:code-transformer code-transformer? code-transformer-ref)
-     (make-struct-type-property 'code-transformer
-                                (lambda (proc info)
-                                  (unless (and (procedure? proc)
-                                               (procedure-arity-includes? proc 2))
-                                    (raise-argument-error 'guard-for-code-transformer
-                                                          "(procedure-arity-includes/c 2)"
-                                                          proc))
-                                  proc)))
+(define code-vl-append
+  (case-lambda
+    [(sep a b) (to-code-pict (vl-append sep a b) b)]
+    [(sep a) a]
+    [(sep a . rest)
+     (code-vl-append sep a (apply code-vl-append sep rest))]))
 
-   (define make-code-transformer
-     (let ()
-       (define-struct code-transformer (proc)
-         #:property prop:code-transformer (lambda (r stx)
-                                            (let ([proc (code-transformer-proc r)])
-                                              (if (syntax? proc)
-                                                  (if (identifier? stx)
-                                                      proc
-                                                      #f) ; => render normally
-                                                  (proc stx)))))
-       (lambda (proc)
-         (unless (or (syntax? proc)
-                     (and (procedure? proc)
-                          (procedure-arity-includes? proc 1)))
-           (raise-argument-error 'make-code-transformer
-                                 "(or/c syntax? (procedure-arity-includes/c 1))"
-                                 proc))
-         (make-code-transformer proc))))
+(begin-for-syntax
+  (define-values (prop:code-transformer code-transformer? code-transformer-ref)
+    (make-struct-type-property 'code-transformer
+                               (lambda (proc info)
+                                 (unless (and (procedure? proc)
+                                              (procedure-arity-includes? proc 2))
+                                   (raise-argument-error 'guard-for-code-transformer
+                                                         "(procedure-arity-includes/c 2)"
+                                                         proc))
+                                 proc)))
+
+  (define make-code-transformer
+    (let ()
+      (define-struct code-transformer (proc)
+        #:property prop:code-transformer (lambda (r stx)
+                                           (let ([proc (code-transformer-proc r)])
+                                             (if (syntax? proc)
+                                                 (if (identifier? stx)
+                                                     proc
+                                                     #f) ; => render normally
+                                                 (proc stx)))))
+      (lambda (proc)
+        (unless (or (syntax? proc)
+                    (and (procedure? proc)
+                         (procedure-arity-includes? proc 1)))
+          (raise-argument-error 'make-code-transformer
+                                "(or/c syntax? (procedure-arity-includes/c 1))"
+                                proc))
+        (make-code-transformer proc))))
    
-   (define (transform id stx uncode-stx recur default)
-     (define r (syntax-local-value id (lambda () #f)))
-     (define t ((code-transformer-ref r) r stx))
-     (if t
-         (recur (datum->syntax stx
-                               (list uncode-stx t)
-                               stx
-                               stx))
-         (default stx))))
+  (define (transform id stx uncode-stx recur default)
+    (define r (syntax-local-value id (lambda () #f)))
+    (define t ((code-transformer-ref r) r stx))
+    (if t
+        (recur (datum->syntax stx
+                              (list uncode-stx t)
+                              stx
+                              stx))
+        (default stx))))
 
-  (define-syntax (define-code stx)
-    (syntax-case stx ()
-      [(_ code typeset-code uncode)
-       (syntax/loc stx
-	 (define-syntax (code stx)
-	   (define (stx->loc-s-expr v)
-	     (cond
-	      [(syntax? v)
-               (define (default v)
-                 (let ([mk `(datum->syntax
-                             #f
-                             ,(syntax-case v (uncode)
-                                [(uncode e) #'e]
-                                 [_ (stx->loc-s-expr (syntax-e v))])
-                              (list 'code
-                                    ,(syntax-line v)
-                                    ,(syntax-column v)
-                                    ,(syntax-position v)
-                                    ,(syntax-span v)))])
-                   (let ([prop (syntax-property v 'paren-shape)])
-                     (if prop
-                         `(syntax-property ,mk 'paren-shape ,prop)
-                         mk))))
-               (syntax-case v ()
-                 [(id e (... ...))
-                  (and (identifier? #'id)
-                       (code-transformer? (syntax-local-value #'id (lambda () #f))))
-                  (transform #'id v (quote-syntax uncode) stx->loc-s-expr default)]
-                 [id
-                  (and (identifier? #'id)
-                       (code-transformer? (syntax-local-value #'id (lambda () #f))))
-                  (transform #'id v (quote-syntax uncode) stx->loc-s-expr default)]
-                 [_ (default v)])]
-              [(pair? v) `(cons ,(stx->loc-s-expr (car v))
-				,(stx->loc-s-expr (cdr v)))]
-	      [(vector? v) `(vector ,@(map
-				       stx->loc-s-expr
-				       (vector->list v)))]
-	      [(box? v) `(box ,(stx->loc-s-expr (unbox v)))]
-	      [(null? v) 'null]
-	      [else `(quote ,v)]))
-	   (define (cvt s)
-	     (datum->syntax #'here (stx->loc-s-expr s)))
-	   (syntax-case stx ()
-	     [(_ expr) #`(typeset-code #,(cvt #'expr))]
-	     [(_ expr (... ...))
-	      #`(typeset-code #,(cvt
-                                 ;; Avoid a syntax location for the synthesized `code:line` wrapper,
-                                 ;; otherwise the `expr`s will be arranged relative to it:
-                                 (datum->syntax #f (cons 'code:line (datum->syntax #f (syntax-e #'(expr (... ...))))))))])))]
-      [(_ code typeset-code) #'(define-code code typeset-code unsyntax)]))
+(define-syntax (define-code stx)
+  (syntax-case stx ()
+    [(_ code typeset-code uncode)
+     (syntax/loc stx
+       (define-syntax (code stx)
+         (define (stx->loc-s-expr v)
+           (cond
+             [(syntax? v)
+              (define (default v)
+                (let ([mk `(datum->syntax
+                            #f
+                            ,(syntax-case v (uncode)
+                               [(uncode e) #'e]
+                               [_ (stx->loc-s-expr (syntax-e v))])
+                            (list 'code
+                                  ,(syntax-line v)
+                                  ,(syntax-column v)
+                                  ,(syntax-position v)
+                                  ,(syntax-span v)))])
+                  (let ([prop (syntax-property v 'paren-shape)])
+                    (if prop
+                        `(syntax-property ,mk 'paren-shape ,prop)
+                        mk))))
+              (syntax-case v ()
+                [(id e (... ...))
+                 (and (identifier? #'id)
+                      (code-transformer? (syntax-local-value #'id (lambda () #f))))
+                 (transform #'id v (quote-syntax uncode) stx->loc-s-expr default)]
+                [id
+                 (and (identifier? #'id)
+                      (code-transformer? (syntax-local-value #'id (lambda () #f))))
+                 (transform #'id v (quote-syntax uncode) stx->loc-s-expr default)]
+                [_ (default v)])]
+             [(pair? v) `(cons ,(stx->loc-s-expr (car v))
+                               ,(stx->loc-s-expr (cdr v)))]
+             [(vector? v) `(vector ,@(map
+                                      stx->loc-s-expr
+                                      (vector->list v)))]
+             [(box? v) `(box ,(stx->loc-s-expr (unbox v)))]
+             [(null? v) 'null]
+             [else `(quote ,v)]))
+         (define (cvt s)
+           (datum->syntax #'here (stx->loc-s-expr s)))
+         (syntax-case stx ()
+           [(_ expr) #`(typeset-code #,(cvt #'expr))]
+           [(_ expr (... ...))
+            #`(typeset-code #,(cvt
+                               ;; Avoid a syntax location for the synthesized `code:line` wrapper,
+                               ;; otherwise the `expr`s will be arranged relative to it:
+                               (datum->syntax #f (cons 'code:line (datum->syntax #f (syntax-e #'(expr (... ...))))))))])))]
+    [(_ code typeset-code) #'(define-code code typeset-code unsyntax)]))
   
-  (define-signature code^
-    (typeset-code code-pict-bottom-line-pict pict->code-pict
-     comment-color keyword-color id-color const-color literal-color
-     code-align current-code-tt current-code-font
-     current-keyword-list current-const-list current-literal-list 
-     code-colorize-enabled code-colorize-quote-enabled 
-     code-italic-underscore-enabled code-scripts-enabled
-     current-comment-color current-keyword-color 
-     current-base-color current-id-color current-literal-color current-const-color
-     current-reader-forms
-     mzscheme-const-list
-     racket/base-const-list))
+(define-signature code^
+  (typeset-code code-pict-bottom-line-pict pict->code-pict
+                comment-color keyword-color id-color const-color literal-color
+                code-align current-code-tt current-code-font
+                current-keyword-list current-const-list current-literal-list 
+                code-colorize-enabled code-colorize-quote-enabled 
+                code-italic-underscore-enabled code-scripts-enabled
+                current-comment-color current-keyword-color 
+                current-base-color current-id-color current-literal-color current-const-color
+                current-reader-forms
+                mzscheme-const-list
+                racket/base-const-list))
 
-  (define-signature code-params^
-    (current-font-size 
-     current-code-line-sep))
+(define-signature code-params^
+  (current-font-size 
+   current-code-line-sep))
 
-  (define-syntax (define-computed stx)
-    (syntax-case stx ()
-      [(_ id v)
-       #'(begin
-	   (define (get-val) v)
-	   (define-syntax id
-	     (syntax-id-rules (set!)
-	       [(x (... ...)) ,illegal-use-of-once]
-	       [x (get-val)])))]))
+(define-syntax (define-computed stx)
+  (syntax-case stx ()
+    [(_ id v)
+     #'(begin
+         (define (get-val) v)
+         (define-syntax id
+           (syntax-id-rules (set!)
+             [(x (... ...)) ,illegal-use-of-once]
+             [x (get-val)])))]))
 
-  ;; Find which line `stx' ends on, #f for unknown
-  (define (syntax-end-line stx)
-    (cond
-     [(syntax? stx) (or (syntax-end-line (syntax-e stx))
-                        (syntax-line stx))]
-     [(pair? stx) (or (syntax-end-line (cdr stx))
-                      (syntax-end-line (car stx)))]
-     [(vector? stx) (syntax-end-line (reverse (vector->list stx)))]
-     [else #f]))
+;; Find which line `stx' ends on, #f for unknown
+(define (syntax-end-line stx)
+  (cond
+    [(syntax? stx) (or (syntax-end-line (syntax-e stx))
+                       (syntax-line stx))]
+    [(pair? stx) (or (syntax-end-line (cdr stx))
+                     (syntax-end-line (car stx)))]
+    [(vector? stx) (syntax-end-line (reverse (vector->list stx)))]
+    [else #f]))
 
-  ;; Find which column `stx' ends on if it's not on `line'
-  (define (syntax-end-column stx line delta)
-    (cond
-     [(syntax? stx) (or (syntax-end-column (syntax-e stx) line delta)
-                        (let ([line2 (syntax-line stx)])
-                          (and line line2
-                               (not (= line line2))
-                               (let ([span (syntax-span stx)]
-                                     [col (syntax-column stx)])
-                                 (and span col (+ col span delta))))))]
-     [(pair? stx) (or (syntax-end-column (cdr stx) line (+ delta 1))
-                      (and (or (null? (cdr stx)) 
-                               (and (syntax? (cdr stx)) (null? (cdr stx))))
-                           (syntax-end-column (car stx) line (+ delta 1))))]
-     [else #f]))
+;; Find which column `stx' ends on if it's not on `line'
+(define (syntax-end-column stx line delta)
+  (cond
+    [(syntax? stx) (or (syntax-end-column (syntax-e stx) line delta)
+                       (let ([line2 (syntax-line stx)])
+                         (and line line2
+                              (not (= line line2))
+                              (let ([span (syntax-span stx)]
+                                    [col (syntax-column stx)])
+                                (and span col (+ col span delta))))))]
+    [(pair? stx) (or (syntax-end-column (cdr stx) line (+ delta 1))
+                     (and (or (null? (cdr stx)) 
+                              (and (syntax? (cdr stx)) (null? (cdr stx))))
+                          (syntax-end-column (car stx) line (+ delta 1))))]
+    [else #f]))
   
-  (define-unit code@
-      (import code-params^)
-      (export code^)
+(define-unit code@
+  (import code-params^)
+  (export code^)
 
-      (define current-code-font (make-parameter `(bold . modern)))
+  (define current-code-font (make-parameter `(bold . modern)))
       
-      (define (default-tt s)
-	(text s (current-code-font) (current-font-size)))
+  (define (default-tt s)
+    (text s (current-code-font) (current-font-size)))
 
-      (define current-code-tt (make-parameter default-tt))
+  (define current-code-tt (make-parameter default-tt))
 
-      (define (tt s)
-	((current-code-tt) s))
+  (define (tt s)
+    ((current-code-tt) s))
 
-      (define (code-align p)
-        (let ([b (dc void 
-                     (pict-width p)
-                     (pict-height p)
-                     (pict-height p)
-                     0)])
-          (refocus (cc-superimpose p b) b)))
+  (define (code-align p)
+    (let ([b (dc void 
+                 (pict-width p)
+                 (pict-height p)
+                 (pict-height p)
+                 0)])
+      (refocus (cc-superimpose p b) b)))
 
-      (define (code-pict-bottom-line-pict p)
-	(if (code-pict? p)
-	    (code-pict-bottom-line p)
-	    #f))
+  (define (code-pict-bottom-line-pict p)
+    (if (code-pict? p)
+        (code-pict-bottom-line p)
+        #f))
 
-      (define (pict->code-pict p bottom-line)
-	(if bottom-line
-	    (to-code-pict p bottom-line)
-	    p))
+  (define (pict->code-pict p bottom-line)
+    (if bottom-line
+        (to-code-pict p bottom-line)
+        p))
       
-    (define (get-vars/bindings ns require-spec)  
-      (define ns (let ([n (make-namespace)])
-                   (parameterize ([current-namespace n])
-                     (namespace-require/copy require-spec))
-                   n))
-      (define bindings (namespace-mapped-symbols ns))
-      (define vars (filter (lambda (n)
-                             (not (eq? 'nope
-                                       (namespace-variable-value n #f (lambda () 'nope) ns))))
-                           bindings))
-      (values vars bindings))
+  (define (get-vars/bindings ns require-spec)  
+    (define ns (let ([n (make-namespace)])
+                 (parameterize ([current-namespace n])
+                   (namespace-require/copy require-spec))
+                 n))
+    (define bindings (namespace-mapped-symbols ns))
+    (define vars (filter (lambda (n)
+                           (not (eq? 'nope
+                                     (namespace-variable-value n #f (lambda () 'nope) ns))))
+                         bindings))
+    (values vars bindings))
     
-    (define-values (mzscheme-vars mzscheme-bindings) (get-vars/bindings (make-namespace) 'mzscheme))
-    (define-values (racket/base-vars racket/base-bindings) (get-vars/bindings (r:make-base-namespace) 'racket/base))
+  (define-values (mzscheme-vars mzscheme-bindings) (get-vars/bindings (make-namespace) 'mzscheme))
+  (define-values (racket/base-vars racket/base-bindings) (get-vars/bindings (r:make-base-namespace) 'racket/base))
     
-      (define current-keyword-list 
-	(make-parameter 
-	 (let ([ht (make-hasheq)])
-           (for-each (lambda (n) (hash-set! ht n #f))
-		     mzscheme-vars)
-           (for-each (lambda (n) (hash-set! ht n #f))
-		     racket/base-vars)
-	   (map symbol->string
-                (filter (lambda (n)
-			  (hash-ref ht n #t))
-                        (append mzscheme-bindings
-                                racket/base-bindings))))))
-      (define current-const-list 
-	(make-parameter '()))
-      (define current-literal-list 
-	(make-parameter '()))
+  (define current-keyword-list 
+    (make-parameter 
+     (let ([ht (make-hasheq)])
+       (for-each (lambda (n) (hash-set! ht n #f))
+                 mzscheme-vars)
+       (for-each (lambda (n) (hash-set! ht n #f))
+                 racket/base-vars)
+       (map symbol->string
+            (filter (lambda (n)
+                      (hash-ref ht n #t))
+                    (append mzscheme-bindings
+                            racket/base-bindings))))))
+  (define current-const-list 
+    (make-parameter '()))
+  (define current-literal-list 
+    (make-parameter '()))
 
-      (define mzscheme-const-list
-	(map symbol->string mzscheme-vars))
-      (define racket/base-const-list
-        (map symbol->string racket/base-vars))
+  (define mzscheme-const-list
+    (map symbol->string mzscheme-vars))
+  (define racket/base-const-list
+    (map symbol->string racket/base-vars))
 
-      (define code-colorize-enabled
-	(make-parameter #t))
+  (define code-colorize-enabled
+    (make-parameter #t))
 
-      (define code-colorize-quote-enabled
-	(make-parameter #t))
+  (define code-colorize-quote-enabled
+    (make-parameter #t))
 
-      (define code-italic-underscore-enabled (make-parameter #t))
-      (define code-scripts-enabled (make-parameter #t))
+  (define code-italic-underscore-enabled (make-parameter #t))
+  (define code-scripts-enabled (make-parameter #t))
 
-      (define (maybe-colorize p c)
-	(if (code-colorize-enabled)
-	    (colorize p c)
-	    p))
+  (define (maybe-colorize p c)
+    (if (code-colorize-enabled)
+        (colorize p c)
+        p))
       
-      (define current-base-color (make-parameter "brown"))
-      (define keyword-color "black")
-      (define current-keyword-color (make-parameter keyword-color))
-      (define id-color "navy")
-      (define current-id-color (make-parameter id-color))
-      (define literal-color (make-object color% 51 135 39))
-      (define current-literal-color (make-parameter literal-color))
-      (define const-color (make-object color% #x99 0 0))
-      (define current-const-color (make-parameter const-color))
-      (define comment-color (current-base-color))
-      (define current-comment-color (make-parameter comment-color))
-      (define current-reader-forms (make-parameter '(quote
-						     quasiquote 
-						     unquote unquote-splicing
-						     syntax
-						     quasisyntax
-						     unsyntax unsyntax-splicing)))
+  (define current-base-color (make-parameter "brown"))
+  (define keyword-color "black")
+  (define current-keyword-color (make-parameter keyword-color))
+  (define id-color "navy")
+  (define current-id-color (make-parameter id-color))
+  (define literal-color (make-object color% 51 135 39))
+  (define current-literal-color (make-parameter literal-color))
+  (define const-color (make-object color% #x99 0 0))
+  (define current-const-color (make-parameter const-color))
+  (define comment-color (current-base-color))
+  (define current-comment-color (make-parameter comment-color))
+  (define current-reader-forms (make-parameter '(quote
+                                                 quasiquote 
+                                                 unquote unquote-splicing
+                                                 syntax
+                                                 quasisyntax
+                                                 unsyntax unsyntax-splicing)))
       
-      (define-computed open-paren-p (tt "("))
-      (define-computed close-paren-p (tt ")"))
-      (define-computed open-sq-p (tt "["))
-      (define-computed close-sq-p (tt "]"))
-      (define-computed open-curly-p (tt "{"))
-      (define-computed close-curly-p (tt "}"))
+  (define-computed open-paren-p (tt "("))
+  (define-computed close-paren-p (tt ")"))
+  (define-computed open-sq-p (tt "["))
+  (define-computed close-sq-p (tt "]"))
+  (define-computed open-curly-p (tt "{"))
+  (define-computed close-curly-p (tt "}"))
 
-      (define-computed quote-p (tt "'"))
-      (define-computed unquote-p (tt ","))
-      (define-computed unquote-splicing-p (tt ",@"))
-      (define-computed quasiquote-p (tt "`"))
-      (define-computed syntax-p (tt "#'"))
-      (define-computed unsyntax-p (tt "#,"))
-      (define-computed unsyntax-splicing-p (tt "#,@"))
-      (define-computed quasisyntax-p (tt "#`"))
-      (define-computed semi-p (tt "; "))
+  (define-computed quote-p (tt "'"))
+  (define-computed unquote-p (tt ","))
+  (define-computed unquote-splicing-p (tt ",@"))
+  (define-computed quasiquote-p (tt "`"))
+  (define-computed syntax-p (tt "#'"))
+  (define-computed unsyntax-p (tt "#,"))
+  (define-computed unsyntax-splicing-p (tt "#,@"))
+  (define-computed quasisyntax-p (tt "#`"))
+  (define-computed semi-p (tt "; "))
 
-      (define (comment-mode? mode)
-	(eq? mode 'comment))
+  (define (comment-mode? mode)
+    (eq? mode 'comment))
       
-      (define-computed dot-p (tt "."))
+  (define-computed dot-p (tt "."))
 
-      (define (mode-colorize mode type p)
-	(maybe-colorize
-	 p
-	 (case mode
-	   [(literal) (current-literal-color)]
-	   [(comment) (current-comment-color)]
-	   [else (cond
-		  [(number? mode) (current-literal-color)]
-		  [(eq? type 'keyword) (current-keyword-color)]
-		  [(eq? type 'literal) (current-literal-color)]
-		  [(eq? type 'const) (current-const-color)]
-		  [(eq? type 'id) (current-id-color)]
-		  [else (current-base-color)])])))
+  (define (mode-colorize mode type p)
+    (maybe-colorize
+     p
+     (case mode
+       [(literal) (current-literal-color)]
+       [(comment) (current-comment-color)]
+       [else (cond
+               [(number? mode) (current-literal-color)]
+               [(eq? type 'keyword) (current-keyword-color)]
+               [(eq? type 'literal) (current-literal-color)]
+               [(eq? type 'const) (current-const-color)]
+               [(eq? type 'id) (current-id-color)]
+               [else (current-base-color)])])))
 	
-      (define (get-open mode stx)
-	(if (memq mode '(contract line))
-	    (blank)
-	    (mode-colorize 
-	     mode #f
-	     (case (syntax-property stx 'paren-shape)
-	       [(#\[) open-sq-p]
-	       [(#\{) open-curly-p]
-	       [else open-paren-p]))))
+  (define (get-open mode stx)
+    (if (memq mode '(contract line))
+        (blank)
+        (mode-colorize 
+         mode #f
+         (case (syntax-property stx 'paren-shape)
+           [(#\[) open-sq-p]
+           [(#\{) open-curly-p]
+           [else open-paren-p]))))
 	
-      (define (get-close mode stx)
-	(if (memq mode '(contract line))
-	    (blank)
-	    (mode-colorize
-	     mode #f
-	     (case (syntax-property stx 'paren-shape)
-	       [(#\[) close-sq-p]
-	       [(#\{) close-curly-p]
-	       [else close-paren-p]))))
+  (define (get-close mode stx)
+    (if (memq mode '(contract line))
+        (blank)
+        (mode-colorize
+         mode #f
+         (case (syntax-property stx 'paren-shape)
+           [(#\[) close-sq-p]
+           [(#\{) close-curly-p]
+           [else close-paren-p]))))
       
-      (define (add-close p closes [force-line #f])
-	(cond
-	 [(null? closes) p]
-	 [(memq (caar closes) '(contract line))
-	  (add-close p (cdr closes) force-line)]
-	 [else
-          (let ([p (if force-line
-                       (vl-append p (tt ""))
-                       p)])
-            (add-close (code-hbl-append p (get-close (caar closes) (cdar closes)))
-                       (cdr closes)
-                       #f))]))
+  (define (add-close p closes [force-line #f])
+    (cond
+      [(null? closes) p]
+      [(memq (caar closes) '(contract line))
+       (add-close p (cdr closes) force-line)]
+      [else
+       (let ([p (if force-line
+                    (vl-append p (tt ""))
+                    p)])
+         (add-close (code-hbl-append p (get-close (caar closes) (cdar closes)))
+                    (cdr closes)
+                    #f))]))
       
-      (define (pad-left space p)
-	(if (= 0 space)
-	    p
-	    (code-htl-append (tt (make-string space #\space)) p)))
+  (define (pad-left space p)
+    (if (= 0 space)
+        p
+        (code-htl-append (tt (make-string space #\space)) p)))
 
-      (define (pad-bottom space p)
-	(if (= 0 space)
-	    p
-	    (code-vl-append (current-code-line-sep) (tt " ") (pad-bottom (sub1 space) p))))
+  (define (pad-bottom space p)
+    (if (= 0 space)
+        p
+        (code-vl-append (current-code-line-sep) (tt " ") (pad-bottom (sub1 space) p))))
 
-      (define (colorize-id str mode)
-	(cond
-	 [(and (code-italic-underscore-enabled)
-	       ((string-length str) . > . 1)
-	       (char=? #\_ (string-ref str 0))
-	       (not (char=? #\_ (string-ref str 1))))
-	  (mode-colorize
-	   mode 'id
-	   (text (substring str 1) `(italic . ,(current-code-font)) (current-font-size)))]
-	 [(and (code-scripts-enabled)
-	       (regexp-match #rx"^(.+)_([0-9a-z()+-]+)\\^([0-9a-z()+-]+)$" str))
-	  => (lambda (m)
-	       (hbl-append (colorize-id (cadr m) mode)
-			   (cc-superimpose
-			    (text (caddr m) `(subscript . ,(current-code-font)) (current-font-size))
-			    (text (cadddr m) `(superscript . ,(current-code-font)) (current-font-size)))))]
-	 [(and (code-scripts-enabled)
-	       (regexp-match #rx"^(.+)\\^([0-9a-z()+-]+)_([0-9a-z()+-]+)$" str))
-	  => (lambda (m)
-	       (hbl-append (colorize-id (cadr m) mode)
-			   (cc-superimpose
-			    (text (cadddr m) `(subscript . ,(current-code-font)) (current-font-size))
-			    (text (caddr m) `(superscript . ,(current-code-font)) (current-font-size)))))]
-	 [(and (code-scripts-enabled)
-	       (regexp-match #rx"^(.+)\\^([0-9a-z()+-]+)$" str))
-	  => (lambda (m)
-	       (hbl-append (colorize-id (cadr m) mode)
-			   (text (caddr m) `(superscript . ,(current-code-font)) (current-font-size))))]
-	 [(and (code-scripts-enabled)
-	       (regexp-match #rx"^(.+)_([0-9a-z()+-]+)$" str))
-	  => (lambda (m)
-	       (hbl-append (colorize-id (cadr m) mode)
-			   (text (caddr m) `(subscript . ,(current-code-font)) (current-font-size))))]
-	 [else
-	  (mode-colorize
-	   mode 
-	   (cond
-	    [(member str (current-keyword-list)) 'keyword]
-	    [(member str (current-const-list)) 'const]
-	    [(member str (current-literal-list)) 'literal]
-	    [else 'id])
-	   (tt str))]))
+  (define (colorize-id str mode)
+    (cond
+      [(and (code-italic-underscore-enabled)
+            ((string-length str) . > . 1)
+            (char=? #\_ (string-ref str 0))
+            (not (char=? #\_ (string-ref str 1))))
+       (mode-colorize
+        mode 'id
+        (text (substring str 1) `(italic . ,(current-code-font)) (current-font-size)))]
+      [(and (code-scripts-enabled)
+            (regexp-match #rx"^(.+)_([0-9a-z()+-]+)\\^([0-9a-z()+-]+)$" str))
+       => (lambda (m)
+            (hbl-append (colorize-id (cadr m) mode)
+                        (cc-superimpose
+                         (text (caddr m) `(subscript . ,(current-code-font)) (current-font-size))
+                         (text (cadddr m) `(superscript . ,(current-code-font)) (current-font-size)))))]
+      [(and (code-scripts-enabled)
+            (regexp-match #rx"^(.+)\\^([0-9a-z()+-]+)_([0-9a-z()+-]+)$" str))
+       => (lambda (m)
+            (hbl-append (colorize-id (cadr m) mode)
+                        (cc-superimpose
+                         (text (cadddr m) `(subscript . ,(current-code-font)) (current-font-size))
+                         (text (caddr m) `(superscript . ,(current-code-font)) (current-font-size)))))]
+      [(and (code-scripts-enabled)
+            (regexp-match #rx"^(.+)\\^([0-9a-z()+-]+)$" str))
+       => (lambda (m)
+            (hbl-append (colorize-id (cadr m) mode)
+                        (text (caddr m) `(superscript . ,(current-code-font)) (current-font-size))))]
+      [(and (code-scripts-enabled)
+            (regexp-match #rx"^(.+)_([0-9a-z()+-]+)$" str))
+       => (lambda (m)
+            (hbl-append (colorize-id (cadr m) mode)
+                        (text (caddr m) `(subscript . ,(current-code-font)) (current-font-size))))]
+      [else
+       (mode-colorize
+        mode 
+        (cond
+          [(member str (current-keyword-list)) 'keyword]
+          [(member str (current-const-list)) 'const]
+          [(member str (current-literal-list)) 'literal]
+          [else 'id])
+        (tt str))]))
 
-      (define (sub-mode mode)
-	(case mode
-	  [(line cond local) #f]
-	  [(template-cond) 'template]
-	  [(contract) 'comment]
-	  [else mode]))
+  (define (sub-mode mode)
+    (case mode
+      [(line cond local) #f]
+      [(template-cond) 'template]
+      [(contract) 'comment]
+      [else mode]))
 
-      (define (cond? s)
-	(memq (syntax-e s) '(cond))) ;  syntax-rules syntax-case)))
+  (define (cond? s)
+    (memq (syntax-e s) '(cond))) ;  syntax-rules syntax-case)))
 
-      (define (local? s)
-	(memq (syntax-e s) '(local)))
+  (define (local? s)
+    (memq (syntax-e s) '(local)))
 
-      (define (get-span stx)
-        (syntax-case stx (code:blank)
-          [code:blank 1]
-          [_ (or (syntax-span stx) 1)]))
+  (define (get-span stx)
+    (syntax-case stx (code:blank)
+      [code:blank 1]
+      [_ (or (syntax-span stx) 1)]))
       
-      (define (color-semi-p)
-	(mode-colorize 'comment #f semi-p))
+  (define (color-semi-p)
+    (mode-colorize 'comment #f semi-p))
 
-      (define (add-semis p)
-	(let loop ([p p] [semis (color-semi-p)])
-	  (if ((pict-height p) . > . (+ (pict-height semis) 1))
-	      (loop p (vl-append (current-code-line-sep) (color-semi-p) semis))
-	      (htl-append semis p))))
+  (define (add-semis p)
+    (let loop ([p p] [semis (color-semi-p)])
+      (if ((pict-height p) . > . (+ (pict-height semis) 1))
+          (loop p (vl-append (current-code-line-sep) (color-semi-p) semis))
+          (htl-append semis p))))
 
-      (define (add-unquote unquote-p loop x closes mode)
-	(let ([mode (cond
-		     [(number? mode) (if (zero? mode)
-					 #f
-					 (sub1 mode))]
-		     [else mode])])
-	  (code-htl-append (mode-colorize mode 'keyword unquote-p) 
-			   (loop x closes mode))))
+  (define (add-unquote unquote-p loop x closes mode)
+    (let ([mode (cond
+                  [(number? mode) (if (zero? mode)
+                                      #f
+                                      (sub1 mode))]
+                  [else mode])])
+      (code-htl-append (mode-colorize mode 'keyword unquote-p) 
+                       (loop x closes mode))))
 
-      (define (typeset-code stx)
-	(let loop ([stx stx][closes null][mode #f])
-	  (syntax-case* stx (quote unquote unquote-splicing quasiquote
-				   syntax-unquote syntax unsyntax
-				   unsyntax-splicing quasisyntax
-				   code:contract code:comment code:line
-				   code:template code:blank $)
-			(lambda (a b) (eq? (syntax-e a) (syntax-e b)))
-	    [() (add-close (htl-append (get-open mode stx) (get-close mode stx))
-			   closes)]
-	    [code:blank (add-close (tt " ")
-                                   closes)]
-	    [$ (colorize-id "|" closes)]
-	    [(quote x)
-	     (memq 'quote (current-reader-forms))
-	     (code-htl-append (mode-colorize mode 'literal quote-p) 
-			      (loop #'x closes (if (or (not (code-colorize-quote-enabled))
-						       (comment-mode? mode))
-						   mode
-						   'literal)))]
-	    [(unquote x)
-	     (memq 'unquote (current-reader-forms))
-	     (add-unquote unquote-p loop #'x closes mode)]
-	    [(unquote-splicing x)
-	     (memq 'unquote-splicing (current-reader-forms))
-	     (add-unquote unquote-splicing-p loop #'x closes mode)]
-	    [(quasiquote x)
-	     (memq 'quasiquote (current-reader-forms))
-	     (code-htl-append (mode-colorize mode 'keyword quasiquote-p) 
-			      (loop #'x closes (cond
-						[(not (code-colorize-quote-enabled)) mode]
-						[(comment-mode? mode) mode]
-						[(number? mode) (add1 mode)]
-						[else 0])))]
-	    [(syntax x)
-	     (memq 'syntax (current-reader-forms))
-	     (code-htl-append (mode-colorize mode 'literal syntax-p) 
-			      (loop #'x closes mode))]
-	    [(unsyntax x)
-	     (memq 'unsyntax (current-reader-forms))
-	     (code-htl-append (mode-colorize mode 'literal unsyntax-p) 
-			      (loop #'x closes mode))]
-	    [(unsyntax-splicing x)
-	     (memq 'unsyntax-splicing (current-reader-forms))
-	     (code-htl-append (mode-colorize mode 'literal unsyntax-splicing-p) 
-			      (loop #'x closes mode))]
-	    [(quasisyntax x)
-	     (memq 'unsyntax-splicing (current-reader-forms))
-	     (code-htl-append (mode-colorize mode 'literal quasisyntax-p) 
-			      (loop #'x closes mode))]
-	    [(code:contract i ...)
-	     (add-semis (loop (datum->syntax #f (syntax->list #'(i ...)))
-			      closes 'contract))]
-	    [(code:line i ...)
-             (loop (datum->syntax #f (syntax->list #'(i ...))
-                                  (syntax-case stx ()
-                                    [(_ a . b)
-                                     (let ([src (syntax-source stx)]
-                                           [line (syntax-line stx)]
-                                           [col (syntax-column stx)]
-                                           [pos (syntax-position stx)]
-                                           [span (syntax-span stx)]
-                                           [a-pos (syntax-position #'a)])
-                                       (if (and pos a-pos (a-pos . > . pos))
-                                           (vector src
-                                                   line
-                                                   (and col (+ col (- a-pos pos)))
-                                                   a-pos
-                                                   (and span (max 0 (- span (- a-pos pos)))))
-                                           stx))]
-                                    [else stx]))
-                   closes 'line)]
-	    [(code:comment s ...)
-	     (let ([p
-                    (apply htl-append 
-                           (color-semi-p)
-                           (map (lambda (s)
-                                  (define datum (syntax-e s))
-                                  (if (pict-convertible? datum)
-                                      datum
-                                      (if (string? datum)
-                                          (maybe-colorize (tt datum) (current-comment-color))
-                                          (raise-argument-error 'code:comment "string?" datum))))
-                                (syntax->list #'(s ...))))])
-               ;; Ungraceful handling of ungraceful closes by adding a line
-               ;; --- better than sticking them to the right of the comment, at least
-               (add-close p closes 'force-line))]
-	    [(code:template i ...)
-	     (add-semis (loop #'(code:line i ...) closes 'template))]
-            [(a b i ... c)
-             (let ([pos (for/fold ([pos (syntax-position #'b)]) ([i (in-list (syntax->list #'(i ... c)))])
-                          (and pos 
-                               (syntax-position i)
-                               ((syntax-position i) . > . pos)
-                               (syntax-position i)))])
-               (and pos 
-                    (syntax-position #'a)
-                    ((syntax-position #'a) . > . (syntax-position #'b))
-                    ((syntax-position #'a) . < . (syntax-position #'c))))
-             ;; position of `a' is after `b', while everything else is in
-             ;; order, so print as infix-dot notation
-             (loop
-              (datum->syntax
-               stx
-               (cons #'b
-                     (let loop ([l (syntax->list #'(i ... c))])
-                       (cond
-                        [((syntax-position #'a) . < . (syntax-position (car l)))
-                         (let ([src (syntax-source #'a)]
-                               [pos (syntax-position #'a)]
-                               [line (syntax-line #'a)]
-                               [col (syntax-column #'a)]
-                               [span (syntax-span #'a)])
-                           (list* (datum->syntax #f '|.| 
-                                                 (vector src line 
-                                                         (and col (max 0 (- col 2))) 
-                                                         (max 1 (- pos 2)) 
-                                                         1))
-                                  #'a 
-                                  (datum->syntax #f '|.| 
-                                                 (vector src line 
-                                                         (and col (+ col 1 span))
-                                                         (+ pos 1 span) 
-                                                         1))
-                                  l))]
-                        [else (cons (car l) (loop (cdr l)))])))
-               stx)
-              closes
-              mode)]
-	    [(i ...)
-	     (let ([is (syntax->list #'(i ...))])
-	       ;; Convert each i to a picture, include close paren in last item:
-	       (let ([ips (let iloop ([is is][sub-mode (sub-mode mode)])
-			    (cond
-			     [(null? (cdr is)) (list (loop (car is) (cons (cons mode stx) closes) sub-mode))]
-			     [else (cons (loop (car is) null sub-mode)
-					 (iloop (cdr is) (cond
-							  [(cond? (car is))
-							   (if (eq? mode 'template)
-							       'template-cond
-							       'cond)]
-							  [(local? (car is))
-							   'local]
-							  [(eq? sub-mode 'local)
-							   #f]
-							  [else
-							   sub-mode])))]))])
-		 ;; Combine the parts:
-		 (let ([left (or (syntax-column stx) +inf.0)])
-		   (let loop ([stxs is]
-			      [ps ips]
-			      [line-so-far (get-open mode stx)]
-			      [col (+ left 1)]
-			      [line (syntax-line stx)]
-			      [always-space? #f]
-                              [col->width (make-hash)])
-		     (cond
-		      [(null? ps) (blank)]
-		      [(or (not line)
-			   (= line (or (syntax-line (car stxs)) line)))
-		       (let* ([space (if (syntax-column (car stxs))
-					 (inexact->exact
-					  (max (if always-space? 1 0) (- (syntax-column (car stxs)) col)))
-					 (if always-space? 1 0))]
-			      [p (code-htl-append
-				  line-so-far
-				  (pad-left space (car ps)))])
-			 (unless (equal? +inf.0 (+ space col))
-			   (hash-set! col->width 
-                                      (+ space col) 
-                                      (pict-width (code-htl-append line-so-far (pad-left space (blank))))))
-			 (if (null? (cdr stxs))
-			     p
-			     (loop (cdr stxs)
-				   (cdr ps)
-				   p
-                                   (or (syntax-end-column (car stxs) line 0)
-                                       (if (not (syntax-column (car stxs)))
-                                           +inf.0
-                                           (+ col space (get-span (car stxs)))))
-				   (or (syntax-end-line (car stxs))
-                                       line 
-                                       (syntax-line (car stxs)))
-				   #t
-                                   col->width)))]
-		      [else
-		       ;; Start on next line:
-		       (code-vl-append
-			(current-code-line-sep)
-			line-so-far
-			(let* ([space (max 0 (- (or (syntax-column (car stxs)) 0) left))]
-			       [p 
-                                (let/ec k
-                                  (code-htl-append
-                                   (blank (hash-ref col->width 
-                                                    (+ space left)
-                                                    (lambda ()
-                                                      (k (pad-left space (car ps)))))
-                                          0)
-                                   (car ps)))])
-			  (if (null? (cdr stxs))
-			      p
-			      (loop (cdr stxs)
-				    (cdr ps)
-				    p
-				    (+ left space (get-span (car stxs)))
-				    (or (syntax-line (car stxs)) (add1 line))
-				    #t
-                                    (let ([ht (make-hash)]
-                                          [v (hash-ref col->width (+ space left) #f)])
-                                      (when v (hash-set! ht (+ space left) v))
-                                      ht)))))])))))]
-	    [id
-	     (identifier? stx)
-	     (add-close (colorize-id (symbol->string (syntax-e stx)) mode) closes)]
-	    [kw
-	     (keyword? (syntax-e #'kw))
-	     (add-close (mode-colorize mode #f (tt (format "~s" (syntax-e stx)))) closes)]
-	    [(a . b)
-             ;; Build a list that makes the "." explicit.
-             (let ([p (let loop ([a (syntax-e stx)])
+  (define (typeset-code stx)
+    (let loop ([stx stx][closes null][mode #f])
+      (syntax-case* stx (quote unquote unquote-splicing quasiquote
+                               syntax-unquote syntax unsyntax
+                               unsyntax-splicing quasisyntax
+                               code:contract code:comment code:line
+                               code:template code:blank $)
+        (lambda (a b) (eq? (syntax-e a) (syntax-e b)))
+        [() (add-close (htl-append (get-open mode stx) (get-close mode stx))
+                       closes)]
+        [code:blank (add-close (tt " ")
+                               closes)]
+        [$ (colorize-id "|" closes)]
+        [(quote x)
+         (memq 'quote (current-reader-forms))
+         (code-htl-append (mode-colorize mode 'literal quote-p) 
+                          (loop #'x closes (if (or (not (code-colorize-quote-enabled))
+                                                   (comment-mode? mode))
+                                               mode
+                                               'literal)))]
+        [(unquote x)
+         (memq 'unquote (current-reader-forms))
+         (add-unquote unquote-p loop #'x closes mode)]
+        [(unquote-splicing x)
+         (memq 'unquote-splicing (current-reader-forms))
+         (add-unquote unquote-splicing-p loop #'x closes mode)]
+        [(quasiquote x)
+         (memq 'quasiquote (current-reader-forms))
+         (code-htl-append (mode-colorize mode 'keyword quasiquote-p) 
+                          (loop #'x closes (cond
+                                             [(not (code-colorize-quote-enabled)) mode]
+                                             [(comment-mode? mode) mode]
+                                             [(number? mode) (add1 mode)]
+                                             [else 0])))]
+        [(syntax x)
+         (memq 'syntax (current-reader-forms))
+         (code-htl-append (mode-colorize mode 'literal syntax-p) 
+                          (loop #'x closes mode))]
+        [(unsyntax x)
+         (memq 'unsyntax (current-reader-forms))
+         (code-htl-append (mode-colorize mode 'literal unsyntax-p) 
+                          (loop #'x closes mode))]
+        [(unsyntax-splicing x)
+         (memq 'unsyntax-splicing (current-reader-forms))
+         (code-htl-append (mode-colorize mode 'literal unsyntax-splicing-p) 
+                          (loop #'x closes mode))]
+        [(quasisyntax x)
+         (memq 'unsyntax-splicing (current-reader-forms))
+         (code-htl-append (mode-colorize mode 'literal quasisyntax-p) 
+                          (loop #'x closes mode))]
+        [(code:contract i ...)
+         (add-semis (loop (datum->syntax #f (syntax->list #'(i ...)))
+                          closes 'contract))]
+        [(code:line i ...)
+         (loop (datum->syntax #f (syntax->list #'(i ...))
+                              (syntax-case stx ()
+                                [(_ a . b)
+                                 (let ([src (syntax-source stx)]
+                                       [line (syntax-line stx)]
+                                       [col (syntax-column stx)]
+                                       [pos (syntax-position stx)]
+                                       [span (syntax-span stx)]
+                                       [a-pos (syntax-position #'a)])
+                                   (if (and pos a-pos (a-pos . > . pos))
+                                       (vector src
+                                               line
+                                               (and col (+ col (- a-pos pos)))
+                                               a-pos
+                                               (and span (max 0 (- span (- a-pos pos)))))
+                                       stx))]
+                                [else stx]))
+               closes 'line)]
+        [(code:comment s ...)
+         (let ([p
+                (apply htl-append 
+                       (color-semi-p)
+                       (map (lambda (s)
+                              (define datum (syntax-e s))
+                              (if (pict-convertible? datum)
+                                  datum
+                                  (if (string? datum)
+                                      (maybe-colorize (tt datum) (current-comment-color))
+                                      (raise-argument-error 'code:comment "string?" datum))))
+                            (syntax->list #'(s ...))))])
+           ;; Ungraceful handling of ungraceful closes by adding a line
+           ;; --- better than sticking them to the right of the comment, at least
+           (add-close p closes 'force-line))]
+        [(code:template i ...)
+         (add-semis (loop #'(code:line i ...) closes 'template))]
+        [(a b i ... c)
+         (let ([pos (for/fold ([pos (syntax-position #'b)]) ([i (in-list (syntax->list #'(i ... c)))])
+                      (and pos 
+                           (syntax-position i)
+                           ((syntax-position i) . > . pos)
+                           (syntax-position i)))])
+           (and pos 
+                (syntax-position #'a)
+                ((syntax-position #'a) . > . (syntax-position #'b))
+                ((syntax-position #'a) . < . (syntax-position #'c))))
+         ;; position of `a' is after `b', while everything else is in
+         ;; order, so print as infix-dot notation
+         (loop
+          (datum->syntax
+           stx
+           (cons #'b
+                 (let loop ([l (syntax->list #'(i ... c))])
+                   (cond
+                     [((syntax-position #'a) . < . (syntax-position (car l)))
+                      (let ([src (syntax-source #'a)]
+                            [pos (syntax-position #'a)]
+                            [line (syntax-line #'a)]
+                            [col (syntax-column #'a)]
+                            [span (syntax-span #'a)])
+                        (list* (datum->syntax #f '|.| 
+                                              (vector src line 
+                                                      (and col (max 0 (- col 2))) 
+                                                      (max 1 (- pos 2)) 
+                                                      1))
+                               #'a 
+                               (datum->syntax #f '|.| 
+                                              (vector src line 
+                                                      (and col (+ col 1 span))
+                                                      (+ pos 1 span) 
+                                                      1))
+                               l))]
+                     [else (cons (car l) (loop (cdr l)))])))
+           stx)
+          closes
+          mode)]
+        [(i ...)
+         (let ([is (syntax->list #'(i ...))])
+           ;; Convert each i to a picture, include close paren in last item:
+           (let ([ips (let iloop ([is is][sub-mode (sub-mode mode)])
                         (cond
-                         [(pair? a) (cons (car a) (loop (cdr a)))]
-                         [else (list (datum->syntax #f
-                                                    (mode-colorize mode #f dot-p)
-                                                    (list (syntax-source a)
-                                                          (syntax-line a)
-                                                          (- (syntax-column a) 2)
-                                                          (- (syntax-position a) 2)
-                                                          1))
-                                     a)]))])
-               (loop (datum->syntax stx
-                                    p
-                                    stx)
-                     closes
-                     mode))]
-            [#(e ...)
-             (code-htl-append (mode-colorize mode 'literal (tt "#"))
-                              (loop (datum->syntax stx
-                                                   (syntax->list #'(e ...))
-                                                   (list (syntax-source stx)
-                                                         (syntax-line stx)
-                                                         (and (syntax-column stx)
-                                                              (+ (syntax-column stx) 1))
-                                                         (and (syntax-position stx)
-                                                              (+ (syntax-position stx) 1))
-                                                         (and (syntax-span stx)
-                                                              (max 0 (- (syntax-span stx) 1)))))
-                                    closes
-                                    mode))]
-            [else
-	     (add-close (if (pict-convertible? (syntax-e stx))
-			    (syntax-e stx)
-			    (mode-colorize mode 'literal
-					   (tt (format "~s" (syntax-e stx)))))
-			closes)])))
+                          [(null? (cdr is)) (list (loop (car is) (cons (cons mode stx) closes) sub-mode))]
+                          [else (cons (loop (car is) null sub-mode)
+                                      (iloop (cdr is) (cond
+                                                        [(cond? (car is))
+                                                         (if (eq? mode 'template)
+                                                             'template-cond
+                                                             'cond)]
+                                                        [(local? (car is))
+                                                         'local]
+                                                        [(eq? sub-mode 'local)
+                                                         #f]
+                                                        [else
+                                                         sub-mode])))]))])
+             ;; Combine the parts:
+             (let ([left (or (syntax-column stx) +inf.0)])
+               (let loop ([stxs is]
+                          [ps ips]
+                          [line-so-far (get-open mode stx)]
+                          [col (+ left 1)]
+                          [line (syntax-line stx)]
+                          [always-space? #f]
+                          [col->width (make-hash)])
+                 (cond
+                   [(null? ps) (blank)]
+                   [(or (not line)
+                        (= line (or (syntax-line (car stxs)) line)))
+                    (let* ([space (if (syntax-column (car stxs))
+                                      (inexact->exact
+                                       (max (if always-space? 1 0) (- (syntax-column (car stxs)) col)))
+                                      (if always-space? 1 0))]
+                           [p (code-htl-append
+                               line-so-far
+                               (pad-left space (car ps)))])
+                      (unless (equal? +inf.0 (+ space col))
+                        (hash-set! col->width 
+                                   (+ space col) 
+                                   (pict-width (code-htl-append line-so-far (pad-left space (blank))))))
+                      (if (null? (cdr stxs))
+                          p
+                          (loop (cdr stxs)
+                                (cdr ps)
+                                p
+                                (or (syntax-end-column (car stxs) line 0)
+                                    (if (not (syntax-column (car stxs)))
+                                        +inf.0
+                                        (+ col space (get-span (car stxs)))))
+                                (or (syntax-end-line (car stxs))
+                                    line 
+                                    (syntax-line (car stxs)))
+                                #t
+                                col->width)))]
+                   [else
+                    ;; Start on next line:
+                    (code-vl-append
+                     (current-code-line-sep)
+                     line-so-far
+                     (let* ([space (max 0 (- (or (syntax-column (car stxs)) 0) left))]
+                            [p 
+                             (let/ec k
+                               (code-htl-append
+                                (blank (hash-ref col->width 
+                                                 (+ space left)
+                                                 (lambda ()
+                                                   (k (pad-left space (car ps)))))
+                                       0)
+                                (car ps)))])
+                       (if (null? (cdr stxs))
+                           p
+                           (loop (cdr stxs)
+                                 (cdr ps)
+                                 p
+                                 (+ left space (get-span (car stxs)))
+                                 (or (syntax-line (car stxs)) (add1 line))
+                                 #t
+                                 (let ([ht (make-hash)]
+                                       [v (hash-ref col->width (+ space left) #f)])
+                                   (when v (hash-set! ht (+ space left) v))
+                                   ht)))))])))))]
+        [id
+         (identifier? stx)
+         (add-close (colorize-id (symbol->string (syntax-e stx)) mode) closes)]
+        [kw
+         (keyword? (syntax-e #'kw))
+         (add-close (mode-colorize mode #f (tt (format "~s" (syntax-e stx)))) closes)]
+        [(a . b)
+         ;; Build a list that makes the "." explicit.
+         (let ([p (let loop ([a (syntax-e stx)])
+                    (cond
+                      [(pair? a) (cons (car a) (loop (cdr a)))]
+                      [else (list (datum->syntax #f
+                                                 (mode-colorize mode #f dot-p)
+                                                 (list (syntax-source a)
+                                                       (syntax-line a)
+                                                       (- (syntax-column a) 2)
+                                                       (- (syntax-position a) 2)
+                                                       1))
+                                  a)]))])
+           (loop (datum->syntax stx
+                                p
+                                stx)
+                 closes
+                 mode))]
+        [#(e ...)
+         (code-htl-append (mode-colorize mode 'literal (tt "#"))
+                          (loop (datum->syntax stx
+                                               (syntax->list #'(e ...))
+                                               (list (syntax-source stx)
+                                                     (syntax-line stx)
+                                                     (and (syntax-column stx)
+                                                          (+ (syntax-column stx) 1))
+                                                     (and (syntax-position stx)
+                                                          (+ (syntax-position stx) 1))
+                                                     (and (syntax-span stx)
+                                                          (max 0 (- (syntax-span stx) 1)))))
+                                closes
+                                mode))]
+        [else
+         (add-close (if (pict-convertible? (syntax-e stx))
+                        (syntax-e stx)
+                        (mode-colorize mode 'literal
+                                       (tt (format "~s" (syntax-e stx)))))
+                    closes)])))
       
-      ))
+  )

--- a/pict-lib/texpict/face.rkt
+++ b/pict-lib/texpict/face.rkt
@@ -1,387 +1,388 @@
-(module face mzscheme
-  (require racket/draw
-           pict/private/pict
-           pict/private/utils
-           mzlib/class
-           mzlib/math
-           mzlib/etc
-           mzlib/kw)
+#lang mzscheme
 
-  (provide face face* default-face-color)
+(require racket/draw
+         pict/private/pict
+         pict/private/utils
+         mzlib/class
+         mzlib/math
+         mzlib/etc
+         mzlib/kw)
+
+(provide face face* default-face-color)
   
-  (define no-brush (find-brush "white" 'transparent))
-  (define no-pen (find-pen "white" 1 'transparent))
+(define no-brush (find-brush "white" 'transparent))
+(define no-pen (find-pen "white" 1 'transparent))
 
-  (define (series dc steps start-c end-c f pen? brush?)
-    (color-series dc steps #e0.5 start-c end-c f pen? brush?))
+(define (series dc steps start-c end-c f pen? brush?)
+  (color-series dc steps #e0.5 start-c end-c f pen? brush?))
 
-  (define default-face-color (make-object color% "orange"))
+(define default-face-color (make-object color% "orange"))
 
-  (define face*
-    (lambda/kw (eyebrows-kind
-                mouth-kind
-                frown?
-                #:optional
-                [in-face-color default-face-color]
-                [eye-inset 0]
-                [eyebrow-dy 0]
-                [eye-dx 0]
-                [eye-dy 0]
-                #:key
-                (mouth-shading? #t)
-                (eye-shading? #t)
-                (eyebrow-shading? #t)
-                (tongue-shading? #t)
-                (face-background-shading? #t)
-                (teeth? #t))
+(define face*
+  (lambda/kw (eyebrows-kind
+              mouth-kind
+              frown?
+              #:optional
+              [in-face-color default-face-color]
+              [eye-inset 0]
+              [eyebrow-dy 0]
+              [eye-dx 0]
+              [eye-dy 0]
+              #:key
+              (mouth-shading? #t)
+              (eye-shading? #t)
+              (eyebrow-shading? #t)
+              (tongue-shading? #t)
+              (face-background-shading? #t)
+              (teeth? #t))
                
-      (define face-color (if (string? in-face-color)
-                             (make-object color% in-face-color)
-                             in-face-color))
-      (define face-bright-edge-color (scale-color #e1.6 face-color))
-      (define face-edge-color (scale-color #e0.8 face-color))
-      (define face-dark-edge-color (scale-color #e0.6 face-color))
-      (define face-hard-edge-color (scale-color #e0.8 face-edge-color))
-      (let ([w 300]
-            [h 300])
-          (dc (lambda (dc x y)
-                (define old-pen (send dc get-pen))
-                (define old-brush (send dc get-brush))
+    (define face-color (if (string? in-face-color)
+                           (make-object color% in-face-color)
+                           in-face-color))
+    (define face-bright-edge-color (scale-color #e1.6 face-color))
+    (define face-edge-color (scale-color #e0.8 face-color))
+    (define face-dark-edge-color (scale-color #e0.6 face-color))
+    (define face-hard-edge-color (scale-color #e0.8 face-edge-color))
+    (let ([w 300]
+          [h 300])
+      (dc (lambda (dc x y)
+            (define old-pen (send dc get-pen))
+            (define old-brush (send dc get-brush))
                 
-                (define (one-eye l? p? dd look?)
-                  (define s (if p? 1/3 1))
-                  (define sdd (if p? 1 1/2))
-                  (define dx (+ (if p? (* 1/5 w 1/3) 0) (if look? eye-dx 0)))
-                  (define dy (+ (if p? (* 1/4 w 1/3) 0) (if look? eye-dy 0)))
-                  (send dc draw-ellipse
-                        (+ x (* w (if l? 1/5 3/5)) dx (* dd sdd)) (+ y (* h 1/5) dy (* dd sdd))
-                        (- (* w 1/5 s) (* 2 dd)) (- (* h 1/4 s) (* 2 dd))))
+            (define (one-eye l? p? dd look?)
+              (define s (if p? 1/3 1))
+              (define sdd (if p? 1 1/2))
+              (define dx (+ (if p? (* 1/5 w 1/3) 0) (if look? eye-dx 0)))
+              (define dy (+ (if p? (* 1/4 w 1/3) 0) (if look? eye-dy 0)))
+              (send dc draw-ellipse
+                    (+ x (* w (if l? 1/5 3/5)) dx (* dd sdd)) (+ y (* h 1/5) dy (* dd sdd))
+                    (- (* w 1/5 s) (* 2 dd)) (- (* h 1/4 s) (* 2 dd))))
                 
-                (define (one-eye-brow l? dd dy dr)
-                  (send dc draw-arc
-                        (+ x (* w (if l? 1/5 3/5)))
-                        (+ y (* h 3/20) dd dy)
-                        (* w 1/5) 
-                        (* h 1/4)
-                        ((if l? + -) (* pi 1/3) dr) ((if l? + -) (* pi 2/3) dr)))
+            (define (one-eye-brow l? dd dy dr)
+              (send dc draw-arc
+                    (+ x (* w (if l? 1/5 3/5)))
+                    (+ y (* h 3/20) dd dy)
+                    (* w 1/5) 
+                    (* h 1/4)
+                    ((if l? + -) (* pi 1/3) dr) ((if l? + -) (* pi 2/3) dr)))
                 
-                (define (eye-series steps start-c end-c p? extra-inset look?)
-                  (series dc
-                          (if eye-shading? steps 0)
-                          start-c end-c
-                          (lambda (i)
-                            (one-eye #t p? (+ extra-inset i) look?)
-                            (one-eye #f p? (+ extra-inset i) look?))
-                          #f #t))
+            (define (eye-series steps start-c end-c p? extra-inset look?)
+              (series dc
+                      (if eye-shading? steps 0)
+                      start-c end-c
+                      (lambda (i)
+                        (one-eye #t p? (+ extra-inset i) look?)
+                        (one-eye #f p? (+ extra-inset i) look?))
+                      #f #t))
                 
-                (define (eyebrows dy dr)
-                  (send dc set-brush no-brush)
-                  (series dc
-                          (if eyebrow-shading? 3 0)
-                          face-hard-edge-color
-                          face-edge-color
-                          (lambda (i)
-                            (one-eye-brow #t i dy dr)
-                            (one-eye-brow #f i dy dr))
-                          #t #f)
-                  (send dc set-pen no-pen))
+            (define (eyebrows dy dr)
+              (send dc set-brush no-brush)
+              (series dc
+                      (if eyebrow-shading? 3 0)
+                      face-hard-edge-color
+                      face-edge-color
+                      (lambda (i)
+                        (one-eye-brow #t i dy dr)
+                        (one-eye-brow #f i dy dr))
+                      #t #f)
+              (send dc set-pen no-pen))
                 
-                (define (normal-eyebrows dy)
-                  (eyebrows dy 0))
+            (define (normal-eyebrows dy)
+              (eyebrows dy 0))
                 
-                (define (worried-eyebrows dy)
-                  (eyebrows dy 0.3))
+            (define (worried-eyebrows dy)
+              (eyebrows dy 0.3))
                 
-                (define (angry-eyebrows dy)
-                  (eyebrows dy -0.3))
+            (define (angry-eyebrows dy)
+              (eyebrows dy -0.3))
                 
-                (define (smile sw sh i da path dy flip?)
-                  ;; Either draw or set path.
-                  ((if path 
-                       (lambda (x y w h s e)
-			 (send path arc x y w h s e))
-                       (lambda (x y w h s e)
-                         (send dc draw-arc x y w h s e)))
-                   (+ x (/ (- w sw) 2) (* 1/6 sw)) 
-                   (+ y (/ (- sh h) 2) (* 1/8 h) dy (if flip? i 0) (if flip? (- (* h 1/2) (- sh h)) 0))
-                   (* sw 2/3) (+ (if flip? 0 i) (* h 2/3))
-                   (- (* pi (- 5/4 (if flip? 1 0))) da) (+ (* pi (- 7/4 (if flip? 1 0))) da)))
+            (define (smile sw sh i da path dy flip?)
+              ;; Either draw or set path.
+              ((if path 
+                   (lambda (x y w h s e)
+                     (send path arc x y w h s e))
+                   (lambda (x y w h s e)
+                     (send dc draw-arc x y w h s e)))
+               (+ x (/ (- w sw) 2) (* 1/6 sw)) 
+               (+ y (/ (- sh h) 2) (* 1/8 h) dy (if flip? i 0) (if flip? (- (* h 1/2) (- sh h)) 0))
+               (* sw 2/3) (+ (if flip? 0 i) (* h 2/3))
+               (- (* pi (- 5/4 (if flip? 1 0))) da) (+ (* pi (- 7/4 (if flip? 1 0))) da)))
                 
-                (define (plain-smile flip? tongue? narrow?)
-		  (send dc set-brush no-brush)
-		  (series dc 
-                          (if mouth-shading? 3 0)
-                          (make-object color% "black")
-                          face-edge-color
-                          (lambda (i)
-                            (let ([da (if narrow? (* pi -1/8) 0)])
-                              (smile w h i da #f 0 flip?)
-                              (smile w h (+ 1 (- i)) da #f 0 flip?)))
-                          #t #f)
-		  (when tongue?
-		    (let ([path (new dc-path%)]
-			  [rgn (make-object region% dc)])
-		      (smile w h 2 0 path 0 flip?)
-		      (send path line-to (+ w x) (+ h y))
-		      (send path line-to x (+ h y))
-		      (send rgn set-path path)
-		      (send dc set-clipping-region rgn)
-		      (send dc set-pen no-pen)
-		      (let ([dx (+ x (if flip?
-					 (* 1/3 w)
-					 (* 1/2 w)))]
-			    [dy (+ y (if flip?
-					 (* 1/2 h)
-					 (* 13/20 h)))]
-			    [tw (* 1/5 w)]
-			    [th (* 1/4 h)])
-			(series dc
-                                (if tongue-shading? 3 0)
-				face-color
-				(make-object color% "red")
-				(lambda (i)
-				  (send dc draw-ellipse dx dy (- tw i) (- th i)))
-				#f #t)
-			(series dc 
-                                (if tongue-shading? 4 0)
-				(make-object color% "black")
-				(scale-color 0.6 (make-object color% "red"))
-				(lambda (i)
-				  (send dc draw-line (- (+ dx i) (* tw 1/10)) dy (+ dx (* tw 0.65)) (+ dy (* th 0.75))))
-				#t #f)
-			(send dc set-clipping-region #f)))))
-                
-                (define (teeth)
-                  ;; Assumes clipping region is set
-                  (send dc set-brush (find-brush "white"))
-                  (send dc draw-ellipse x y w h)
-                  (when teeth?
-                    (series dc 
-                            5
-                            (make-object color% "darkgray")
-                            (make-object color% "lightgray")
-                            (lambda (i)
-                              (let loop ([j 0][delta 0][tw (* w 1/10)])
-                                (unless (= j 5)
-                                  (send dc draw-rectangle
-                                        (+ x (* w 1/2) delta 1) y
-                                        (- tw i 1) h)
-                                  (send dc draw-rectangle
-                                        (+ x (* w 1/2) (- delta) (- tw) 1) y
-                                        (- tw i 1) h)
-                                  (loop (add1 j) (+ delta tw) (* 8/10 tw)))))
-                            #f #t)))
-                
-                (define (toothy-smile tw th ta bw bh ba flip? ddy)
-                  (let-values ([(path) (make-object dc-path%)]
-			       [(tmp-rgn1) (make-object region% dc)]
-                               [(dy) (+ ddy (/ (- h (if flip? (+ th (abs (- bh th))) th)) 2))])
-                    ;; Teeth:
-                    (smile tw th 0 ta path dy flip?)
-		    (send path reverse)
-                    (smile bw bh 0 ba path dy flip?)
-		    (send tmp-rgn1 set-path path)
-                    (send dc set-clipping-region tmp-rgn1)
-                    (teeth)
-                    (send dc set-clipping-region #f)
-                    
-                    ;; Smile edges:
-                    (send dc set-brush no-brush)
-                    (series dc 
-                            (if mouth-shading? 3 0)
-                            (if flip? face-bright-edge-color face-hard-edge-color)
-                            (if flip? face-color face-edge-color)
-                            (lambda (i)
-                              (smile bw bh (if flip? i (- i)) ba #f dy flip?))
-                            #t #f)
+            (define (plain-smile flip? tongue? narrow?)
+              (send dc set-brush no-brush)
+              (series dc 
+                      (if mouth-shading? 3 0)
+                      (make-object color% "black")
+                      face-edge-color
+                      (lambda (i)
+                        (let ([da (if narrow? (* pi -1/8) 0)])
+                          (smile w h i da #f 0 flip?)
+                          (smile w h (+ 1 (- i)) da #f 0 flip?)))
+                      #t #f)
+              (when tongue?
+                (let ([path (new dc-path%)]
+                      [rgn (make-object region% dc)])
+                  (smile w h 2 0 path 0 flip?)
+                  (send path line-to (+ w x) (+ h y))
+                  (send path line-to x (+ h y))
+                  (send rgn set-path path)
+                  (send dc set-clipping-region rgn)
+                  (send dc set-pen no-pen)
+                  (let ([dx (+ x (if flip?
+                                     (* 1/3 w)
+                                     (* 1/2 w)))]
+                        [dy (+ y (if flip?
+                                     (* 1/2 h)
+                                     (* 13/20 h)))]
+                        [tw (* 1/5 w)]
+                        [th (* 1/4 h)])
                     (series dc
-                            (if mouth-shading? 3 0)
-                            (if flip? face-hard-edge-color face-bright-edge-color)
-                            (if flip? face-edge-color face-color)
-                            (lambda (i)
-                              (smile tw th (if flip? (- i) i) ta #f dy flip?))
-                            #t #f)))
-                
-                (define (grimace tw th ta flip?)
-                  (let-values ([(path) (make-object dc-path%)]
-                               [(tmp-rgn1) (make-object region% dc)]
-                               [(dy) (/ (- h th) 2)]
-                               [(elx ely) (values (+ x (* w 0.27)) (+ y (* h 0.65) (if flip? 3 1)))])
-                    ;; Teeth:
-		    (smile tw th 0 ta path (+ (if flip? -30 0) dy) flip?)
-		    (send path arc elx ely 30 30 (* 1/2 pi) (* 3/2 pi) #t)
-		    (send path reverse)
-		    (send path arc (- (+ x w) (- elx x) 30) ely 30 30 (* 1/2 pi) (* 3/2 pi) #f)
-		    (smile tw th 0 ta path (+ (if flip? 0 -30) dy) flip?)
-                    (send tmp-rgn1 set-path path)
-                    (send dc set-clipping-region tmp-rgn1)
-		    (teeth)
-                    (send dc set-clipping-region #f)
-		    
-                    ;; Smile edges:
-                    (send dc set-brush no-brush)
-                    (let ([sides (lambda (top? i)
-                                   (send dc draw-arc (- elx (/ i 2)) (- ely (/ i 2)) 30 (+ 30 i) 
-                                         (* pi (if top? 1 1/2)) (* pi (if top? 3/2 1)))
-                                   (send dc draw-arc (+ (- (+ x w) (- elx x) 30) (/ i 2)) (- ely (/ i 2)) 30 (+ 30 i) 
-                                         (* pi (if top? -1/2 0)) (* pi (if top? 0 1/2))))])
-                      (series dc 
-                              (if mouth-shading? 3 0)
-                              (if flip? face-bright-edge-color face-hard-edge-color)
-                              (if flip? face-color face-edge-color)
-                              (lambda (i)
-                                (sides flip? i)
-                                (smile tw th (if flip? i (- i)) ta #f (+ (if flip? -2 -30) dy) flip?))
-                              #t #f)
-                      (series dc 
-                              (if mouth-shading? 3 0)
-                              (if flip? face-hard-edge-color face-bright-edge-color)
-                              (if flip? face-edge-color face-color)
-                              (lambda (i)
-                                (sides (not flip?) i)
-                                (smile tw th (if flip? (- i) i) ta #f (+ (if flip? -30 0) dy) flip?))
-                              #t #f))))
-                
-                (define (medium-grimace flip?)
-                  (grimace
-                   (* 1.2 w) (* h 0.9) (- (* 0.1 pi)) 
-                   flip?))
-                
-                (define (narrow-grimace flip?)
-                  (grimace
-                   (* 1.2 w) (* h 0.9) (- (* 0.1 pi))
-                   flip?))
-                
-                (define (large-smile flip?)
-                  (toothy-smile
-                   w (* 1.05 h) (* 0.10 pi)
-                   (* 1.1 w) (* h 0.95) (* 0.05 pi)
-                   flip? 0))
-                
-                (define (largest-smile flip?)            
-                  (toothy-smile
-                   w (* 1.1 h) (* 0.14 pi)
-                   (* 1.2 w) (* h 0.9) (* 0.05 pi)
-                   flip? (if flip? (* h 0.1) 0)))
-                
-                (define (narrow-smile flip?)
-                  (toothy-smile
-                   (* 0.8 w) (* h 0.7) (- (* 0.00 pi))
-                   (* 1.0 w) (* h 0.6) (- (* 0.06 pi))
-                   flip? (if flip? (- (* h 0.2)) 0)))
-                
-                (define (medium-smile flip?)
-                  (toothy-smile
-                   (* 0.8 w) (* h 0.9) (* 0.08 pi)
-                   (* 1.0 w) (* h 0.75) (- (* 0.01 pi))
-                   flip? 0))
-                
-                (define (oh)
-                  (let ([do-draw
-                         (λ (i)
-                           (let ([sw (* w 7/20)]
-                                 [sh (* h 8/20)])
-                             (send dc draw-ellipse
-                                   (+ x i (/ (- w sw) 2))
-                                   (+ y (* i .75) (* h 1/4) (* h -1/16) (/ (- h sh) 2))
-                                   (- sw (* i 2))
-                                   (- sh (* i 2)))))])
-                    (series dc 
-                            (if mouth-shading? 5 0)
+                            (if tongue-shading? 3 0)
                             face-color
-                            face-dark-edge-color
-                            do-draw
-                            #t #t)
-                    (send dc set-brush (find-brush "black"))
-                    (send dc set-pen no-pen)
-                    (do-draw 9)))
+                            (make-object color% "red")
+                            (lambda (i)
+                              (send dc draw-ellipse dx dy (- tw i) (- th i)))
+                            #f #t)
+                    (series dc 
+                            (if tongue-shading? 4 0)
+                            (make-object color% "black")
+                            (scale-color 0.6 (make-object color% "red"))
+                            (lambda (i)
+                              (send dc draw-line (- (+ dx i) (* tw 1/10)) dy (+ dx (* tw 0.65)) (+ dy (* th 0.75))))
+                            #t #f)
+                    (send dc set-clipping-region #f)))))
                 
-                (define (draw-eyes inset)
-                  ;; Draw eyes
-                  (eye-series 10 
-                              (make-object color% "lightgray")
-                              (make-object color% "white")
-                              #f
-                              inset
-                              #f)
-                  
-                  ;; Draw pupils
-                  (eye-series 3
-                              (make-object color% 220 220 220)
-                              (make-object color% "black")
-                              #t
-                              0
-                              #t))
-                
-                (send dc set-pen no-pen)
-                
-                ;; Draw face background
-                (series dc
-                        (if face-background-shading? 3 0)
-                        face-edge-color
-                        face-color
+            (define (teeth)
+              ;; Assumes clipping region is set
+              (send dc set-brush (find-brush "white"))
+              (send dc draw-ellipse x y w h)
+              (when teeth?
+                (series dc 
+                        5
+                        (make-object color% "darkgray")
+                        (make-object color% "lightgray")
                         (lambda (i)
-                          (send dc draw-ellipse 
-                                (+ x (/ i 2)) (+ y (/ i 2))
-                                (- w (* 2 i)) (- h (* 2 i))))
-                        #f #t)
-
-		(draw-eyes eye-inset)
-		(case eyebrows-kind
-		  [(normal) (normal-eyebrows eyebrow-dy)]
-		  [(worried) (worried-eyebrows eyebrow-dy)]
-		  [(angry) (angry-eyebrows eyebrow-dy)]
-		  [(none) (void)])
-		(case mouth-kind
-		  [(plain) (plain-smile frown? #f #f)]
-		  [(smaller) (plain-smile frown? #f #t)]
-                  [(narrow) (narrow-smile frown?)]
-		  [(medium) (medium-smile frown?)]
-		  [(large) (large-smile frown?)]
-		  [(huge) (largest-smile frown?)]
-		  [(grimace) (medium-grimace frown?)]
-                  [(oh) (oh)]
-		  [(tongue) (plain-smile frown? #t #f)])
+                          (let loop ([j 0][delta 0][tw (* w 1/10)])
+                            (unless (= j 5)
+                              (send dc draw-rectangle
+                                    (+ x (* w 1/2) delta 1) y
+                                    (- tw i 1) h)
+                              (send dc draw-rectangle
+                                    (+ x (* w 1/2) (- delta) (- tw) 1) y
+                                    (- tw i 1) h)
+                              (loop (add1 j) (+ delta tw) (* 8/10 tw)))))
+                        #f #t)))
                 
-                (send dc set-brush old-brush)
-                (send dc set-pen old-pen))
-              w h 0 0))))
+            (define (toothy-smile tw th ta bw bh ba flip? ddy)
+              (let-values ([(path) (make-object dc-path%)]
+                           [(tmp-rgn1) (make-object region% dc)]
+                           [(dy) (+ ddy (/ (- h (if flip? (+ th (abs (- bh th))) th)) 2))])
+                ;; Teeth:
+                (smile tw th 0 ta path dy flip?)
+                (send path reverse)
+                (smile bw bh 0 ba path dy flip?)
+                (send tmp-rgn1 set-path path)
+                (send dc set-clipping-region tmp-rgn1)
+                (teeth)
+                (send dc set-clipping-region #f)
+                    
+                ;; Smile edges:
+                (send dc set-brush no-brush)
+                (series dc 
+                        (if mouth-shading? 3 0)
+                        (if flip? face-bright-edge-color face-hard-edge-color)
+                        (if flip? face-color face-edge-color)
+                        (lambda (i)
+                          (smile bw bh (if flip? i (- i)) ba #f dy flip?))
+                        #t #f)
+                (series dc
+                        (if mouth-shading? 3 0)
+                        (if flip? face-hard-edge-color face-bright-edge-color)
+                        (if flip? face-edge-color face-color)
+                        (lambda (i)
+                          (smile tw th (if flip? (- i) i) ta #f dy flip?))
+                        #t #f)))
+                
+            (define (grimace tw th ta flip?)
+              (let-values ([(path) (make-object dc-path%)]
+                           [(tmp-rgn1) (make-object region% dc)]
+                           [(dy) (/ (- h th) 2)]
+                           [(elx ely) (values (+ x (* w 0.27)) (+ y (* h 0.65) (if flip? 3 1)))])
+                ;; Teeth:
+                (smile tw th 0 ta path (+ (if flip? -30 0) dy) flip?)
+                (send path arc elx ely 30 30 (* 1/2 pi) (* 3/2 pi) #t)
+                (send path reverse)
+                (send path arc (- (+ x w) (- elx x) 30) ely 30 30 (* 1/2 pi) (* 3/2 pi) #f)
+                (smile tw th 0 ta path (+ (if flip? 0 -30) dy) flip?)
+                (send tmp-rgn1 set-path path)
+                (send dc set-clipping-region tmp-rgn1)
+                (teeth)
+                (send dc set-clipping-region #f)
+		    
+                ;; Smile edges:
+                (send dc set-brush no-brush)
+                (let ([sides (lambda (top? i)
+                               (send dc draw-arc (- elx (/ i 2)) (- ely (/ i 2)) 30 (+ 30 i) 
+                                     (* pi (if top? 1 1/2)) (* pi (if top? 3/2 1)))
+                               (send dc draw-arc (+ (- (+ x w) (- elx x) 30) (/ i 2)) (- ely (/ i 2)) 30 (+ 30 i) 
+                                     (* pi (if top? -1/2 0)) (* pi (if top? 0 1/2))))])
+                  (series dc 
+                          (if mouth-shading? 3 0)
+                          (if flip? face-bright-edge-color face-hard-edge-color)
+                          (if flip? face-color face-edge-color)
+                          (lambda (i)
+                            (sides flip? i)
+                            (smile tw th (if flip? i (- i)) ta #f (+ (if flip? -2 -30) dy) flip?))
+                          #t #f)
+                  (series dc 
+                          (if mouth-shading? 3 0)
+                          (if flip? face-hard-edge-color face-bright-edge-color)
+                          (if flip? face-edge-color face-color)
+                          (lambda (i)
+                            (sides (not flip?) i)
+                            (smile tw th (if flip? (- i) i) ta #f (+ (if flip? -30 0) dy) flip?))
+                          #t #f))))
+                
+            (define (medium-grimace flip?)
+              (grimace
+               (* 1.2 w) (* h 0.9) (- (* 0.1 pi)) 
+               flip?))
+                
+            (define (narrow-grimace flip?)
+              (grimace
+               (* 1.2 w) (* h 0.9) (- (* 0.1 pi))
+               flip?))
+                
+            (define (large-smile flip?)
+              (toothy-smile
+               w (* 1.05 h) (* 0.10 pi)
+               (* 1.1 w) (* h 0.95) (* 0.05 pi)
+               flip? 0))
+                
+            (define (largest-smile flip?)            
+              (toothy-smile
+               w (* 1.1 h) (* 0.14 pi)
+               (* 1.2 w) (* h 0.9) (* 0.05 pi)
+               flip? (if flip? (* h 0.1) 0)))
+                
+            (define (narrow-smile flip?)
+              (toothy-smile
+               (* 0.8 w) (* h 0.7) (- (* 0.00 pi))
+               (* 1.0 w) (* h 0.6) (- (* 0.06 pi))
+               flip? (if flip? (- (* h 0.2)) 0)))
+                
+            (define (medium-smile flip?)
+              (toothy-smile
+               (* 0.8 w) (* h 0.9) (* 0.08 pi)
+               (* 1.0 w) (* h 0.75) (- (* 0.01 pi))
+               flip? 0))
+                
+            (define (oh)
+              (let ([do-draw
+                     (λ (i)
+                       (let ([sw (* w 7/20)]
+                             [sh (* h 8/20)])
+                         (send dc draw-ellipse
+                               (+ x i (/ (- w sw) 2))
+                               (+ y (* i .75) (* h 1/4) (* h -1/16) (/ (- h sh) 2))
+                               (- sw (* i 2))
+                               (- sh (* i 2)))))])
+                (series dc 
+                        (if mouth-shading? 5 0)
+                        face-color
+                        face-dark-edge-color
+                        do-draw
+                        #t #t)
+                (send dc set-brush (find-brush "black"))
+                (send dc set-pen no-pen)
+                (do-draw 9)))
+                
+            (define (draw-eyes inset)
+              ;; Draw eyes
+              (eye-series 10 
+                          (make-object color% "lightgray")
+                          (make-object color% "white")
+                          #f
+                          inset
+                          #f)
+                  
+              ;; Draw pupils
+              (eye-series 3
+                          (make-object color% 220 220 220)
+                          (make-object color% "black")
+                          #t
+                          0
+                          #t))
+                
+            (send dc set-pen no-pen)
+                
+            ;; Draw face background
+            (series dc
+                    (if face-background-shading? 3 0)
+                    face-edge-color
+                    face-color
+                    (lambda (i)
+                      (send dc draw-ellipse 
+                            (+ x (/ i 2)) (+ y (/ i 2))
+                            (- w (* 2 i)) (- h (* 2 i))))
+                    #f #t)
 
-  (define-syntax (case/good-error-message stx)
-    (syntax-case stx (else)
-      [(_ test [(sym ...) e] ... [else x last-e])
-       (syntax
-        (case test 
-          [(sym ...) e]  ...
-          [else (let ([x (apply append '((sym ...) ...))]) last-e)]))]))
+            (draw-eyes eye-inset)
+            (case eyebrows-kind
+              [(normal) (normal-eyebrows eyebrow-dy)]
+              [(worried) (worried-eyebrows eyebrow-dy)]
+              [(angry) (angry-eyebrows eyebrow-dy)]
+              [(none) (void)])
+            (case mouth-kind
+              [(plain) (plain-smile frown? #f #f)]
+              [(smaller) (plain-smile frown? #f #t)]
+              [(narrow) (narrow-smile frown?)]
+              [(medium) (medium-smile frown?)]
+              [(large) (large-smile frown?)]
+              [(huge) (largest-smile frown?)]
+              [(grimace) (medium-grimace frown?)]
+              [(oh) (oh)]
+              [(tongue) (plain-smile frown? #t #f)])
+                
+            (send dc set-brush old-brush)
+            (send dc set-pen old-pen))
+          w h 0 0))))
+
+(define-syntax (case/good-error-message stx)
+  (syntax-case stx (else)
+    [(_ test [(sym ...) e] ... [else x last-e])
+     (syntax
+      (case test 
+        [(sym ...) e]  ...
+        [else (let ([x (apply append '((sym ...) ...))]) last-e)]))]))
       
-  (define face
-    (opt-lambda (mood [face-color default-face-color])
-      (case/good-error-message mood
-	[(unhappy)
-	 (face* 'none 'plain #t face-color 6)]
-	[(sortof-happy)
-	 (face* 'worried 'medium #f face-color 6)]
-	[(sortof-unhappy)
-	 (face* 'worried 'grimace #t face-color 6)]
-	[(happy)
-	 (face* 'none 'plain #f face-color 6)]
-	[(happier)
-	 (face* 'none 'large #f face-color 3)]
-	[(embarrassed embarassed) ; keep older misspelled name
-	 (face* 'worried 'medium #f face-color 3)]
-	[(badly-embarrassed badly-embarassed) ; here too
-	 (face* 'worried 'medium #t face-color 3)]
-	[(unhappier)
-	 (face* 'normal 'large #t face-color 3)]
-	[(happiest)
-	 (face* 'normal 'huge #f face-color 0 -3)]
-	[(unhappiest)
-	 (face* 'normal 'huge #t face-color 0 -3)]
-        [(mad)
-         (face* 'angry 'grimace #t face-color 0)]
-        [(mean)
-         (face* 'angry 'narrow #f face-color 0)]
-        [(surprised)
-         (face* 'worried 'oh #t face-color -4 -3 2)]
-	[else all-ids (error 'face "unknown mood: ~e, expected one of ~s" mood all-ids)]))))
+(define face
+  (opt-lambda (mood [face-color default-face-color])
+    (case/good-error-message mood
+                             [(unhappy)
+                              (face* 'none 'plain #t face-color 6)]
+                             [(sortof-happy)
+                              (face* 'worried 'medium #f face-color 6)]
+                             [(sortof-unhappy)
+                              (face* 'worried 'grimace #t face-color 6)]
+                             [(happy)
+                              (face* 'none 'plain #f face-color 6)]
+                             [(happier)
+                              (face* 'none 'large #f face-color 3)]
+                             [(embarrassed embarassed) ; keep older misspelled name
+                              (face* 'worried 'medium #f face-color 3)]
+                             [(badly-embarrassed badly-embarassed) ; here too
+                              (face* 'worried 'medium #t face-color 3)]
+                             [(unhappier)
+                              (face* 'normal 'large #t face-color 3)]
+                             [(happiest)
+                              (face* 'normal 'huge #f face-color 0 -3)]
+                             [(unhappiest)
+                              (face* 'normal 'huge #t face-color 0 -3)]
+                             [(mad)
+                              (face* 'angry 'grimace #t face-color 0)]
+                             [(mean)
+                              (face* 'angry 'narrow #f face-color 0)]
+                             [(surprised)
+                              (face* 'worried 'oh #t face-color -4 -3 2)]
+                             [else all-ids (error 'face "unknown mood: ~e, expected one of ~s" mood all-ids)])))


### PR DESCRIPTION
This pull request cleans up files using the file-level `(module ...)` mechanism to instead use `#lang`. Then the files were reindented using DrRacket's default indenting preferences.