### PR TITLE
Add various explanations and translations (Fixes #56)

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -162,7 +162,7 @@ A @racket[child] structure is normally not created directly with
 
 @defproc[(explain-child
           [p pict-convertible?]
-          [path pict-path?]
+          [path pict-path?] ...
           [#:border bord (or/c #f string? (is-a?/c color%)) "firered"]
           [#:ascent asc (or/c #f string? (is-a?/c color%)) "seagreen"]
           [#:baseline base (or/c #f string? (is-a?/c color%)) "royalblue"]
@@ -171,7 +171,7 @@ A @racket[child] structure is normally not created directly with
          pict?]{
 
  Like @racket[explain], except the the explanation is drawn for
- some inner @racket[pict] of @racket[p], pointed to by @racket[path].
+ some each inner @racket[pict] of @racket[p], pointed to by @racket[path].
       
  @(examples
    #:eval ss-eval
@@ -180,7 +180,8 @@ A @racket[child] structure is normally not created directly with
    (define t3 (vl-append t1 t2))
    (explain-child t3 t3)
    (explain-child t3 t1)
-   (explain-child t3 t2))
+   (explain-child t3 t2)
+   (explain-child t3 t1 t2))
  
  @history[#:added "1.10"]{}
                                                 

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -118,8 +118,8 @@ own last sub-pict.}
                   [dy real?]
                   [sx real?]
                   [sy real?]
-                  [sxy real?]
-                  [syx real?])]{
+                  [syx real?]
+                  [sxy real?])]{
 
 Records, for a pict constructed of other picts, the transformation to
 arrive at a @tech{inverted point} in the composed pict from an
@@ -136,14 +136,16 @@ A @racket[child] structure is normally not created directly with
                   [#:border bord (or/c #f string? (is-a?/c color%)) "firered"]
                   [#:ascent asc (or/c #f string? (is-a?/c color%)) "seagreen"]
                   [#:baseline base (or/c #f string? (is-a?/c color%)) "royalblue"]
-                  [#:scale s real? 5])
+                  [#:scale s real? 5]
+                  [#:line-width lw real? 1])
          pict?]{
 
  Draw a @racket[pict] like @racket[p], but the pict's bounding box
  is framed in the color @racket[bord], the baseline
  is draw in @racket[base], and the line defined by the ascent
  is drawn in @racket[asc]. If any are @racket[#f] then that part is not
- drawn. The pict is scaled up by @racket[s]. 
+ drawn. The pict is scaled up by @racket[s]. The lines drawn
+ are of width @racket[lw] before scaling is applied.
 
  Note that for single lines of text the baseline and ascent
  are the same, so only one line will be visible.
@@ -153,7 +155,33 @@ A @racket[child] structure is normally not created directly with
    (define tt (vl-append t t))
    (explain t)
    (explain tt))
+ 2             
+ @history[#:added "1.10"]{}
+                                                
+}
 
+@defproc[(explain-child
+          [p pict-convertible?]
+          [path pict-path?]
+          [#:border bord (or/c #f string? (is-a?/c color%)) "firered"]
+          [#:ascent asc (or/c #f string? (is-a?/c color%)) "seagreen"]
+          [#:baseline base (or/c #f string? (is-a?/c color%)) "royalblue"]
+          [#:scale s real? 5]
+          [#:line-width lw real? 1])
+         pict?]{
+
+ Like @racket[explain], except the the explanation is drawn for
+ some inner @racket[pict] of @racket[p], pointed to by @racket[path].
+      
+ @(examples
+   #:eval ss-eval
+   (define t1 (text "ij"))
+   (define t2 (text "ij"))
+   (define t3 (vl-append t1 t2))
+   (explain-child t3 t3)
+   (explain-child t3 t1)
+   (explain-child t3 t2))
+ 
  @history[#:added "1.10"]{}
                                                 
 }

--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -155,7 +155,7 @@ A @racket[child] structure is normally not created directly with
    (define tt (vl-append t t))
    (explain t)
    (explain tt))
- 2             
+
  @history[#:added "1.10"]{}
                                                 
 }

--- a/pict-lib/info.rkt
+++ b/pict-lib/info.rkt
@@ -13,4 +13,4 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.9")
+(define version "1.10")

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -53,6 +53,12 @@
  pin-arrows-line
  pin-line
  (contract-out
+  [explain (->* (pict-convertible?)
+                (#:border (or/c #f string? (is-a?/c color%))
+                 #:ascent (or/c #f string? (is-a?/c color%))
+                 #:baseline (or/c #f string? (is-a?/c color%))
+                 #:scale real?)
+                pict?)]
   [launder (-> pict-convertible? pict-convertible?)]
   [blank
    (case->
@@ -325,6 +331,36 @@
 
 (define (multiple-of-four-bytes? b)
   (zero? (modulo (bytes-length b) 4)))
+
+(define (explain x
+                 #:border [b "Firebrick"]
+                 #:ascent [a "MediumSeaGreen"]
+                 #:baseline [d "DodgerBlue"]
+                 #:scale [s 5])
+  (define f
+    (if (not b)
+        (ghost x)
+        (colorize (frame (ghost x)) b)))
+  (define f+d
+    (if (not d)
+        f
+        (pin-line
+         #:color d
+         f f
+         (lambda _ (values 0 (- (pict-height x) (pict-descent x))))
+         f
+         (lambda _ (values (pict-width x) (- (pict-height x) (pict-descent x)))))))
+  (define f+d+a
+    (if (not a)
+        f+d
+        (pin-line
+         #:color a
+         f+d f+d
+         (lambda _ (values (pict-width x) (pict-ascent x)))
+         f+d
+         (lambda _ (values 0 (pict-ascent x))))))
+  (scale (refocus (cc-superimpose x f+d+a) x) s))
+
 
 (require "private/play-pict.rkt")
 (provide

--- a/pict-lib/pict/main.rkt
+++ b/pict-lib/pict/main.rkt
@@ -64,12 +64,13 @@
          #:line-width real?)
         pict?)]
   [explain-child
-   (->* (pict-convertible? pict-path?)
+   (->* (pict-convertible?)
         (#:border (or/c #f string? (is-a?/c color%))
          #:ascent (or/c #f string? (is-a?/c color%))
          #:baseline (or/c #f string? (is-a?/c color%))
          #:scale real?
          #:line-width real?)
+        #:rest (listof pict-path?)
         pict?)]
   [launder (-> pict-convertible? pict-convertible?)]
   [blank
@@ -350,15 +351,24 @@
                  #:baseline [d "DodgerBlue"]
                  #:scale [s 5]
                  #:line-width [lw 1])
-  (explain-child p p #:border b #:ascent a #:baseline d #:scale s #:line-width lw))
+  (explain-child* p p b a d s lw))
 (define (explain-child
          p
-         child-path
          #:border [b "Firebrick"]
          #:ascent [a "MediumSeaGreen"]
          #:baseline [d "DodgerBlue"]
          #:scale [s 5]
-         #:line-width [lw 1])
+         #:line-width [lw 1]
+         . child-path)
+  (scale
+   (for/fold ([p p])
+             ([c (in-list child-path)])
+     (explain-child* p c b a d 1 lw))
+   s))
+(define (explain-child*
+         p
+         child-path
+         b a d s lw)
   (define t (get-child-transformation p child-path))
   (define child (last (flatten child-path)))
   (define cw (pict-width child))

--- a/pict-lib/pict/private/transform.rkt
+++ b/pict-lib/pict/private/transform.rkt
@@ -1,0 +1,114 @@
+#lang racket/base
+(require "pict.rkt" racket/match racket/list)
+(provide get-child-transformation)
+
+;; get a matrix suitable for the transform method of
+;; dc<%> which shifts one into the drawing coordinates
+;; of the pict given by the pict path pp.
+(define (get-child-transformation p pp)
+  (convert-affine-form
+   (uninvert-coordinartes
+    p (last (flatten pp))
+    (cond
+      [(pict-convertible? pp)
+       (if (pict-path-element=? p pp)
+           (vector 1 0 0
+                   0 1 0
+                   0 0 1)
+           (get-child-transformation/search
+            p (list pp)))]
+      [else
+       (get-child-transformation/search
+        p pp)]))))
+
+;; Transformations here are represented by 3x3
+;; matricies to allow for easy composition. This
+;; converts back to the 2x3 form used by dc<%>
+(define (convert-affine-form v)
+  (match-define (vector a b e c d f _ _ _) v)
+  (vector
+   a b
+   c d
+   e f))
+
+(define (get-child-transformation/search pict list)
+  (cond  [(empty? list)
+          (vector 1 0 0
+                  0 1 0
+                  0 0 1)]
+         [else
+          (define t
+            (find-next-target pict (first list)))
+          (transformation-compose
+           (get-child-transformation/search (first list) (rest list))
+           t)]))
+
+
+(define (find-next-target p target)
+  (let loop ([p p]
+             [children (pict-children p)]
+             [foundk (lambda (t) t)]
+             [failk (lambda () (error 'explain-child "could not find child pict"))])       
+    (match children
+      [(list) (failk)]
+      [(cons r h)
+       #:when (pict-path-element=? (child-pict r) target)
+       (foundk (child->transformation p r))]
+      [(cons r h)
+       (loop
+        (child-pict r)
+        (pict-children (child-pict r))
+        (lambda (t) (foundk (transformation-compose (child->transformation p r) t)))
+        (lambda () (loop p h foundk failk)))])))
+      
+(define (transformation-compose1 t1 t2)
+  (define w 3)
+  (for*/vector #:length 9 #:fill 0
+    ([i (in-range w)]
+     [j (in-range w)])
+    (for/sum ([k (in-range w)])
+      (* (vector-ref t1 (+ (* i w) k))
+         (vector-ref t2 (+ (* w k) j))))))
+
+(define (transformation-compose t1 . t2)
+  (match t2
+    [(list) t1]
+    [(cons r h)
+     (apply
+      transformation-compose
+      (transformation-compose1 t1 r)
+      h)]))
+
+(define (transformation-apply t v)
+  (define w 3)
+  (for/vector #:length 3 #:fill 0
+    ([i (in-range w)])
+    (for/sum ([j (in-range w)])
+      (* (vector-ref v j) (vector-ref t (+ (* i w) j))))))
+
+;; switch from the inverted coordinates used by
+;; pict-child to normal drawing coordinates.
+(define (uninvert-coordinartes p c t)
+  (match-define (vector sx sxy dx syx sy dy _ _ _) t)
+  (match-define
+    (vector _ _ ndx _ _ ndy _ _ _)
+    (transformation-compose
+     (vector
+      1 0 0
+      0 -1 (pict-height p)
+      0 0 1)
+     t
+     (vector
+      1 0 0
+      0 -1 (pict-height c)
+      0 0 1)))
+  (vector
+   sx sxy ndx
+   syx sy ndy
+   0 0 1))
+
+(define (child->transformation parent c)
+  (vector
+   (child-sx c) (child-sxy c) (child-dx c)
+   (child-syx c) (child-sy c) (child-dy c)
+   0 0 1))

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -1238,14 +1238,11 @@
              (if (and bb? (dy . > . 0))
                  (+ (pict-descent p) dy)
                  (pict-descent p))
-             (map (lambda (c)
-                    (make-child
-                     (child-pict c)
-                     (child-dx c)
-                     (+ dx (child-dy c))
-                     1 1
-                     0 0))
-                  (pict-children p))
+             (list
+              (make-child p
+                          dx (- dy) 
+                          1 1
+                          0 0))
              #f
              (pict-last p)))
 


### PR DESCRIPTION
This commit attempt to build some alternatives to `lift-above-baseline`
and `drop-below-ascent`. To do this introduces a `translate` function, which
shifts pict's around. In addition it introduces the function `explain`,
which attempts to annotate picts to show their baseline and ascent.

I'm not 100% sure these functions are what we want though: I couldn't divine the intended behavior
of `lift-above-baseline`, so this is a shot at something I think is reasonable and possibly useful?

The new doc's look something like this:

![Screen Shot 2019-12-13 at 4 29 29 PM](https://user-images.githubusercontent.com/1413610/70836488-e53d8b00-1dc5-11ea-99c8-9ef790f42742.png)
![Screen Shot 2019-12-13 at 4 29 35 PM](https://user-images.githubusercontent.com/1413610/70836489-e53d8b00-1dc5-11ea-9c55-3de39db60901.png)
![Screen Shot 2019-12-13 at 4 29 57 PM](https://user-images.githubusercontent.com/1413610/70836490-e53d8b00-1dc5-11ea-8ac7-51842efeb90a.png)
![Screen Shot 2019-12-13 at 4 30 11 PM](https://user-images.githubusercontent.com/1413610/70836491-e53d8b00-1dc5-11ea-84a1-a4733969fa68.png)
