### PR TITLE
doc: add links, fix variable name

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -428,8 +428,8 @@ then it determines the radius of a circle touching the edges
 in each corner, and the rounding of the rectangle follow the
 edge of those circles. If it is a negative number, then the
 radius of the circles in the corners is the absolute value of the
-@racket[corner-radius] times the smaller of @racket[width]
-and @racket[height].
+@racket[corner-radius] times the smaller of @racket[w]
+and @racket[h].
 
 The @racket[angle] determines how much the rectangle is
 rotated, in radians.

--- a/pict-doc/pict/scribblings/shadow.scrbl
+++ b/pict-doc/pict/scribblings/shadow.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label pict pict/shadow racket/base racket/contract)
+@(require (for-label pict pict/shadow racket/base racket/contract racket/class racket/draw)
           scribble/eval)
 
 @(define the-eval (make-base-eval))


### PR DESCRIPTION
- pict/shadow: import for-label for (is-a?/c color%)
- pict: in filled-rounded-rectange, rename 'width' to 'w' to match contract