### PR TITLE
reorder child struct fields to match docs + use

### DIFF
--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -251,7 +251,7 @@
 (define-pict-setter panbox)
 (define-pict-setter last)
 
-(define-struct child (pict dx dy sx sy syx sxy))
+(define-struct child (pict dx dy sx sy sxy syx))
 (define-struct bbox (x1 y1 x2 y2 ay dy))
 
 (define (pict-convertible? x)


### PR DESCRIPTION
The definition of the `child` struct swaps the order of the fields `sxy` and `syx`, relative to the docs and to the one use of the selectors in `pict-lib/pict/private/pict.rkt`.

This is backwards incompatible

Any ideas for how to find code that this patch might affect? The only tool I can think that might help is `grep` ... because reordering won't break any picts.

(`ppict`, for one, does not use these child selectors)