### PR TITLE
Fix incorrect ascent of codeblock-pict when #:keep-lang-line? is #f

### DIFF
--- a/pict-lib/pict/code.rkt
+++ b/pict-lib/pict/code.rkt
@@ -225,12 +225,10 @@
   (define first-line (first lines))
   (define (format-line l) (apply hbl-append (map token->pict l)))
   (apply vl-append
-         ;; FIXME: #lang can span lines
-         ;;   (codeblock has same issue)
-         (if keep-lang-line?
-             (format-line first-line)
-             (blank))
-         (map format-line (rest lines))))
+         (map format-line
+              ;; FIXME: #lang can span lines
+              ;;   (codeblock has same issue)
+              (if keep-lang-line? lines (rest lines)))))
 
 (define current-token-class->color
   (make-parameter

--- a/pict-test/tests/pict/code.rkt
+++ b/pict-test/tests/pict/code.rkt
@@ -91,3 +91,7 @@ END
 ;; windows newlines should work
 (define example3 "#lang racket\r\n(define x 2)\r\nx")
 (test-codeblock-pict-hash example3 #"b32d6e6f8f33dd9a79a6846fede88246")
+
+;; ascent should not be zero for a single line
+(define example4 (codeblock-pict #:keep-lang-line? #f "#lang racket\n(define foo 42)"))
+(check-pred (λ (v) (> v 0)) (pict-ascent example4))


### PR DESCRIPTION
The current approach for dropping the `#lang` line in `codeblock-pict` actually inserts a zero-height pict for the first line, which screws up `pict-ascent` (it will always be 0). This changes `codeblock-pict` so it drops the first line completely.