### PR TITLE
Ensure `pict-path?` always works for pict-convertibles

### DIFF
--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -40,12 +40,6 @@
     (refocus (cc-superimpose p f)
              p)))
 
-(define (pict-path? p)
-  (or (pict-convertible? p)
-      (and (pair? p)
-           (list? p)
-           (andmap pict-convertible? p))))
-
 (define (label-line label pict src-pict src-coord-fn dest-pict dest-coord-fn
                     #:x-adjust [x-adjust 0] #:y-adjust [y-adjust 0])
   (let-values ([(src-x src-y) (src-coord-fn pict src-pict)]

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -10,7 +10,8 @@
            "convertible.rkt"
            "pict.rkt")
 
-  (provide cons-colorized-picture
+  (provide pict-path?
+     cons-colorized-picture
 	   color-frame
 	   round-frame
 	   color-round-frame
@@ -63,10 +64,10 @@
 	   hyperlinkize)
   
   (define (pict-path? p)
-    (or (pict? p) 
+    (or (pict-convertible? p)
         (and (pair? p)
              (list? p)
-             (andmap pict? p))))
+             (andmap pict-convertible? p))))
   
   (provide/contract 
    [scale (case-> (-> pict-convertible? number? number? pict?)


### PR DESCRIPTION
The contracts for functions like `pin-line` used a different (and presumably outdated) version of `pict-path?` that was too strict and didn't allow for pict convertibles.