### PR TITLE
Fix internal error where source and dest are the same

### DIFF
--- a/pict-lib/pict/private/main.rkt
+++ b/pict-lib/pict/private/main.rkt
@@ -171,9 +171,9 @@
   (let-values ([(sx0 sy0) (src-find p src)]
                [(dx0 dy0) (dest-find p dest)])
     (let* ([sa (or sa
-                   (atan (- sy0 dy0) (- dx0 sx0)))]
+                   (get-angle (- sy0 dy0) (- dx0 sx0)))]
            [ea (or ea
-                   (atan (- sy0 dy0) (- dx0 sx0)))]
+                   (get-angle (- sy0 dy0) (- dx0 sx0)))]
            [d (sqrt (+ (* (- dy0 sy0) (- dy0 sy0)) (* (- dx0 sx0) (- dx0 sx0))))]
            [sp (* (or sp 1/4) d)]
            [ep (* (or ep 1/4) d)])

--- a/pict-lib/pict/private/utils.rkt
+++ b/pict-lib/pict/private/utils.rkt
@@ -46,6 +46,7 @@
 	   add-line
 	   add-arrow-line
 	   add-arrows-line
+	   get-angle
 
 	   bitmap-draft-mode
 
@@ -356,7 +357,7 @@
      `((connect 0 0 ,dx ,(- dy)))))
 
   (define (arrow-line dx dy size)
-    (let-values ([(a adx ady) (arrowhead/delta 0 size (atan dy dx) #t)])
+    (let-values ([(a adx ady) (arrowhead/delta 0 size (get-angle dy dx) #t)])
       (picture
        0 0
        `((connect 0 0 ,dx ,dy)
@@ -1063,8 +1064,8 @@
       (let ([arrows
              (let ([p (cons-picture
                        (ghost (launder base))
-                       `(,(let* ([angle (atan (- sy dy) 
-                                              (- sx dx))]
+                       `(,(let* ([angle (get-angle (- sy dy)
+                                                   (- sx dx))]
                                  [cosa (cos angle)]
                                  [sina (sin angle)]
                                  ;; If there's an arrow, line goes only half-way in
@@ -1079,8 +1080,8 @@
                                              (arrowhead/delta
                                               (or thickness 0)
                                               arrow-size 
-                                              (atan (- dy sy) 
-                                                    (- dx sx))
+                                              (get-angle (- dy sy)
+                                                         (- dx sx))
                                               solid-head?)])
                                  `((place ,(+ dx xo) ,(+ dy yo) ,arrow)))
                                null)
@@ -1090,8 +1091,8 @@
                                              (arrowhead/delta
                                               (or thickness 0)
                                               arrow-size 
-                                              (atan (- sy dy) 
-                                                    (- sx dx))
+                                              (get-angle (- sy dy)
+                                                         (- sx dx))
                                               solid-head?)])
                                  `((place ,(+ sx xo) ,(+ sy yo) ,arrow)))
                                null)))])
@@ -1109,6 +1110,11 @@
              (cc-superimpose arrows base)
              (cc-superimpose base arrows))
          base))))
+
+  (define (get-angle x y)
+    (if (and (zero? x) (zero? y))
+        0
+        (atan x y)))
 
   (define add-line
     (lambda (base src find-src dest find-dest [thickness #f] [color #f] [under? #f])

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -689,3 +689,17 @@
                 (pin-over (hc-append 5 p1-p p2-p) p1-p lt-find p3-p))
   (check-pict=? (pin-under (hc-append 5 p1 p2) p1 lt-find p3-p)
                 (pin-under (hc-append 5 p1-p p2-p) p1-p lt-find p3-p)))
+
+;; ensure that lines where the to and from are the same don't error
+(let ()
+  (define stage (frame (blank 100)))
+  (define big (colorize (disk 50) "red"))
+  (define small (colorize (disk 20) "blue"))
+  (define stage* (cc-superimpose stage big))
+  (define stage** (cc-superimpose stage* small))
+
+  (check-not-exn (λ () (pin-line stage** big cc-find small cc-find)))
+  (check-not-exn (λ () (pin-arrow-line 5 stage** big cc-find small cc-find #:start-angle 0.5)))
+  (check-not-exn (λ () (pin-arrow-line 5 stage** big cc-find small cc-find)))
+  (check-not-exn (λ () (pin-arrows-line 5 stage** big cc-find small cc-find)))
+  (check-not-exn (λ () (pip-arrow-line 0 0 10))))


### PR DESCRIPTION
The `pin-line`, `pin-arrow-line`, `pin-arrows-line`, and `pip-arrow-line` functions fail with an internal error when the source and destination are at the same location because it attempts to calculate the angle between the two with `atan` which fails on `(atan 0 0)`. This commit uses an angle of `0` in this edge case.