### PR TITLE
Add `invert?` option to naive layered layout

### DIFF
--- a/pict-doc/pict/scribblings/tree-layout.scrbl
+++ b/pict-doc/pict/scribblings/tree-layout.scrbl
@@ -93,13 +93,16 @@ that render them as @racket[pict]s.
 
 @defproc[(naive-layered [tree-layout tree-layout?]
                         [#:x-spacing x-spacing (or/c (and/c real? positive?) #f) #f]
-                        [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f])
+                        [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f]
+                        [#:invert? invert? boolean? #f])
          pict?]{
   Uses a naive algorithm that ensures that all nodes at a fixed
   depth are the same vertical distance from the root (dubbed ``layered'').
   It recursively lays out subtrees and then horizontally
   combines them, aligning them at their tops. Then it places
-  the root node centered over the children nodes.
+  the root node centered over the children nodes. If
+  @racket[#:invert?] is @racket[#t], then the axes are flipped
+  and subtrees are combined vertically instead of horizontally.
   
   @examples[#:eval 
             tree-layout-eval
@@ -136,7 +139,10 @@ that render them as @racket[pict]s.
                   #f)
                  #f)
                 #f)))
-            (naive-layered right-subtree-with-left-chain)]
+            (naive-layered right-subtree-with-left-chain)
+            (naive-layered right-subtree-with-left-chain #:invert? #t)]
+
+  @history[#:changed "1.13" @list{Added the @racket[#:invert?] option.}]
 }
                 
 @defproc[(binary-tidier [tree-layout binary-tree-layout?]

--- a/pict-lib/pict/tree-layout.rkt
+++ b/pict-lib/pict/tree-layout.rkt
@@ -48,6 +48,7 @@
   [naive-layered (->* (tree-layout?)
                       (#:x-spacing 
                        (or/c (and/c real? positive?) #f)
-                       #:y-spacing (or/c (and/c real? positive?) #f))
+                       #:y-spacing (or/c (and/c real? positive?) #f)
+                       #:invert? boolean?)
                       pict?)]))
 

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -7,6 +7,7 @@
          pict/code
          pict/conditional
          pict/balloon
+         pict/tree-layout
          racket/draw racket/class)
 
 (define (->bitmap p)
@@ -703,3 +704,14 @@
   (check-not-exn (λ () (pin-arrow-line 5 stage** big cc-find small cc-find)))
   (check-not-exn (λ () (pin-arrows-line 5 stage** big cc-find small cc-find)))
   (check-not-exn (λ () (pip-arrow-line 0 0 10))))
+
+;; for a symmetric tree, invert? is a pi/2 rad. rotation
+(let ()
+  (define t
+    (tree-layout
+     (tree-edge #:edge-style 'transparent (tree-layout))
+     (tree-edge #:edge-style 'transparent (tree-layout))))
+
+  (check-pict=?
+    (rotate (naive-layered t) (/ pi 2))
+    (naive-layered t #:invert? #t)))


### PR DESCRIPTION
I wanted to use tree layout functions for a decision tree, which are usually drawn horizontally instead of vertically. I couldn't find a nice way to do that. This PR adds an option for the naive algorithm to draw in this orientation. Here's a picture:

![invert](https://ccs.neu.edu/~camoy/invert.png)