### PR TITLE
Add `transform` argument to tree layouts

### DIFF
--- a/pict-doc/pict/scribblings/tree-layout.scrbl
+++ b/pict-doc/pict/scribblings/tree-layout.scrbl
@@ -93,7 +93,8 @@ that render them as @racket[pict]s.
 
 @defproc[(naive-layered [tree-layout tree-layout?]
                         [#:x-spacing x-spacing (or/c (and/c real? positive?) #f) #f]
-                        [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f])
+                        [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f]
+                        [#:transform transform (-> real? real? (values real? real?)) values])
          pict?]{
   Uses a naive algorithm that ensures that all nodes at a fixed
   depth are the same vertical distance from the root (dubbed ``layered'').
@@ -101,6 +102,12 @@ that render them as @racket[pict]s.
   combines them, aligning them at their tops. Then it places
   the root node centered over the children nodes.
   
+  The @racket[transform] argument applies a coordinate
+  transformation to each of the nodes after it has been layed out.
+  The bounding box of the resulting pict encompasses the corners
+  of the original bounding box after the transformation has been
+  applied to them.
+
   @examples[#:eval 
             tree-layout-eval
             (define (complete d)
@@ -110,7 +117,7 @@ that render them as @racket[pict]s.
                       (tree-layout s s)]))
             
             (naive-layered (complete 4))
-            
+            (naive-layered (complete 4) #:transform (lambda (x y) (values y x)))
             (naive-layered (tree-layout
                             (tree-layout)
                             (tree-layout)
@@ -137,11 +144,14 @@ that render them as @racket[pict]s.
                  #f)
                 #f)))
             (naive-layered right-subtree-with-left-chain)]
+
+  @history[#:changed "1.13" @list{Added the @racket[#:transform] option.}]
 }
                 
 @defproc[(binary-tidier [tree-layout binary-tree-layout?]
                         [#:x-spacing x-spacing (or/c (and/c real? positive?) #f) #f]
-                        [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f])
+                        [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f]
+                        [#:transform transform (-> real? real? (values real? real?)) values])
          pict?]{
   Uses the layout algorithm from
   @italic{Tidier Drawing of Trees} by Edward M. Reingold and John S. Tilford
@@ -173,6 +183,7 @@ that render them as @racket[pict]s.
   it is the width of the widest node @racket[pict?] in the tree. 
   If @racket[y-spacing] is @racket[#f],
   it is @racket[1.5] times the width of the widest node @racket[pict?] in the tree. 
+  The @racket[transform] is the same as in @racket[naive-layered].
   
   @examples[#:eval 
             tree-layout-eval
@@ -190,12 +201,13 @@ that render them as @racket[pict]s.
             
             (binary-tidier right-subtree-with-left-chain)]
 
-
+  @history[#:changed "1.13" @list{Added the @racket[#:transform] option.}]
 }
 
 @defproc[(hv-alternating [tree-layout binary-tree-layout?]
                          [#:x-spacing x-spacing (or/c (and/c real? positive?) #f) #f]
-                         [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f])
+                         [#:y-spacing y-spacing (or/c (and/c real? positive?) #f) #f]
+                         [#:transform transform (-> real? real? (values real? real?)) values])
          pict?]{
                 
   Uses the ``CT'' binary tree layout algorithm from 
@@ -205,11 +217,13 @@ that render them as @racket[pict]s.
   
   It adds horizontal and vertical space between layers based on @racket[x-spacing] and
   @racket[y-spacing]. If either is @racket[#f], @racket[1.5] times the size of the biggest
-  node is used.
+  node is used.  The @racket[transform] is the same as in @racket[naive-layered].
                 
   @examples[#:eval 
             tree-layout-eval
             (hv-alternating (complete 8))]
+
+  @history[#:changed "1.13" @list{Added the @racket[#:transform] option.}]
 }
 
 @history[#:added "6.0.1.4"]

--- a/pict-lib/pict/private/hv.rkt
+++ b/pict-lib/pict/private/hv.rkt
@@ -11,46 +11,46 @@ Computational Geometry, Theory and Applications 2 (1992)
 
 |#
 (provide hv-alternating)
-(define (hv-alternating t #:x-spacing [given-x-spacing #f] #:y-spacing [given-y-spacing #f])
+(define (hv-alternating t
+                        #:x-spacing [given-x-spacing #f]
+                        #:y-spacing [given-y-spacing #f]
+                        #:transform [transform #f])
   (define-values (x-size y-size) (compute-spacing t #f #f))
   (define x-spacing (or given-x-spacing (* x-size 1.5)))
   (define y-spacing (or given-y-spacing (* y-size 1.5)))
-  (inset
-   (let loop ([t t]
-              [l #t])
-     (match t
-       [#f (blank)]
-       [(tree-layout pict (list left right))
-        (define-values (left-t left-color left-width left-style)
-          (match left
-            [#f (values #f #f #f #f)]
-            [(tree-edge child color width style) (values child color width style)]))
-        (define-values (right-t right-color right-width right-style)
-          (match right
-            [#f (values #f #f #f #f)]
-            [(tree-edge child color width style) (values child color width style)]))
-        (cond
-          [(and (not left-t) (not right-t)) 
-           (dot-ize pict)]
-          [(not left-t) 
-           (empty-left (dot-ize pict) x-spacing right-color right-width right-style (loop right-t (not l)))]
-          [(not right-t)
-           (empty-right (dot-ize pict) y-spacing left-color left-width left-style (loop left-t (not l)))]
-          [else
-           (define left-p (loop left-t (not l)))
-           (define right-p (loop right-t (not l)))
-           (define main
-             ((if l left-right top-bottom)
-              x-spacing y-spacing
-              left-p right-p))
-           (pin-over
-            (add-lines main left-color right-color left-width right-width left-style right-style
-                       left-p right-p)
-            (- (/ (pict-width pict) 2))
-            (- (/ (pict-height pict) 2))
-            pict)])]))
-   (/ x-size 2)
-   (/ y-size 2)))
+  (define t-unique (uniquify-picts t))
+  (define main
+    (inset
+     (let loop ([t t-unique]
+                [l #t])
+       (match t
+         [#f (blank)]
+         [(tree-layout pict (list left right))
+          (define left-t (and (tree-edge? left) (tree-edge-child left)))
+          (define right-t (and (tree-edge? right) (tree-edge-child right)))
+          (cond
+            [(and (not left-t) (not right-t))
+             (dot-ize pict)]
+            [(not left-t)
+             (empty-left (dot-ize pict) x-spacing (loop right-t (not l)))]
+            [(not right-t)
+             (empty-right (dot-ize pict) y-spacing (loop left-t (not l)))]
+            [else
+             (define left-p (loop left-t (not l)))
+             (define right-p (loop right-t (not l)))
+             (define main
+               ((if l left-right top-bottom)
+                x-spacing y-spacing
+                left-p right-p))
+             (pin-over
+              main
+              (- (/ (pict-width pict) 2))
+              (- (/ (pict-height pict) 2))
+              pict)])]))
+     (/ x-size 2)
+     (/ y-size 2)))
+
+  (transform-tree-pict t-unique main transform))
 
 (define (dot-ize p)
   (define b (blank))
@@ -68,38 +68,11 @@ Computational Geometry, Theory and Applications 2 (1992)
    (ht-append (blank hgap 0) left)
    right))
 
-(define (empty-left pict hgap color width style sub-tree-p)
-  (add-a-line (ht-append hgap pict sub-tree-p)
-              color 
-              width style
-              sub-tree-p))
-  
-(define (empty-right pict vgap color width style sub-tree-p)
-  (add-a-line (vl-append vgap pict sub-tree-p)
-              color
-              width style
-              sub-tree-p))
+(define (empty-left pict hgap sub-tree-p)
+  (ht-append hgap pict sub-tree-p))
 
-(define (add-lines main left-color right-color left-width right-width left-style right-style t1 t2)
-  (add-a-line (add-a-line main left-color left-width left-style t1)
-              right-color right-width right-style t2))
-  
-(define (add-a-line main color width style sub)
-  (define colored
-    (colorize
-      (pin-line (ghost main)
-                main lt-find
-                sub lt-find)
-      color))
-  (define with-linewidth
-    (if (eq? width 'unspecified)
-        colored
-        (linewidth width colored)))
-  (define with-linestyle
-    (if (eq? style 'unspecified) with-linewidth (linestyle style with-linewidth)))
-  (cc-superimpose
-   (launder with-linestyle)
-   main))
+(define (empty-right pict vgap sub-tree-p)
+  (vl-append vgap pict sub-tree-p))
 
 (module+ test
   (require rackunit)

--- a/pict-lib/pict/tree-layout.rkt
+++ b/pict-lib/pict/tree-layout.rkt
@@ -36,18 +36,17 @@
   [rename _tree-layout? tree-layout? (-> any/c boolean?)]
   [binary-tree-layout? (-> any/c boolean?)]
   [binary-tidier (->* (binary-tree-layout?)
-                      (#:x-spacing 
-                       (or/c (and/c real? positive?) #f)
-                       #:y-spacing (or/c (and/c real? positive?) #f))
+                      (#:x-spacing (or/c (and/c real? positive?) #f)
+                       #:y-spacing (or/c (and/c real? positive?) #f)
+                       #:transform (-> real? real? (values real? real?)))
                       pict?)]
   [hv-alternating (->* (binary-tree-layout?)
-                       (#:x-spacing 
-                        (or/c (and/c real? positive?) #f)
-                        #:y-spacing (or/c (and/c real? positive?) #f))
+                       (#:x-spacing (or/c (and/c real? positive?) #f)
+                        #:y-spacing (or/c (and/c real? positive?) #f)
+                        #:transform (-> real? real? (values real? real?)))
                        pict?)]
   [naive-layered (->* (tree-layout?)
-                      (#:x-spacing 
-                       (or/c (and/c real? positive?) #f)
-                       #:y-spacing (or/c (and/c real? positive?) #f))
+                      (#:x-spacing (or/c (and/c real? positive?) #f)
+                       #:y-spacing (or/c (and/c real? positive?) #f)
+                       #:transform (-> real? real? (values real? real?)))
                       pict?)]))
-


### PR DESCRIPTION
This is a bigger diff than I had imagined, but I think it improves the existing code in more than one way. It adds
a `#:transform` argument to each of the tree layout functions. I didn't change how they lay out nodes, but instead use the position of the node subpicts to calculate the transformed version. (If no `#:transform` is specified, it just uses the original pict.) I had originally tried to incorporate the transform directly into the calculation of the layout. This worked alright for `binary-tidier`, but not the others since they aren't really coordinate-oriented. A nice side-effect of this way of doing things is that it makes it easy to support transforms for future layout algorithms.

Since the transform needs to be able to draw edges between the transformed points, I was also able to factor out the drawing code for edges. Each of the layout algorithms had more or less the same edge drawing logic, so there was a lot of duplicated code. Edge drawing now happens in one place now.

Finally, since this is a pretty large change, I used randomized testing to check that for hundreds of randomly generated trees this PR didn't change the behavior of the tree layout functions under the identity transform. (A good thing I did because I messed up the bounding box calculation at first!)