### PR TITLE
Add flip procedures

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -938,6 +938,20 @@ scale while drawing the original @racket[pict].
 
 }
 
+@defproc*[([(flip-x [pict pict-convertible?]) pict?]
+           [(flip-y [pict pict-convertible?]) pict?])]{
+Flips a pict drawing horizontally or vertically.
+
+@examples[#:eval ss-eval
+          (standard-fish 100 50)
+          (flip-x (standard-fish 100 50))
+          (flip-x (flip-x (standard-fish 100 50)))
+          (flip-y (standard-fish 100 50))
+          (flip-y (flip-y (standard-fish 100 50)))
+          (flip-y (flip-x (standard-fish 100 50)))
+          (flip-x (flip-y (standard-fish 100 50)))]
+}
+
 @defproc*[([(scale-to-fit [pict pict-convertible?] [size-pict pict-convertible?]
                           [#:mode mode (or/c 'preserve 'inset
                                              'preserve/max 'inset/max

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -744,3 +744,25 @@
          [alg (in-list layout-algs)])
     (define t (rand-bin-tree))
     (check-pict=? (alg t) (alg t #:transform values))))
+
+(test-case "Flips"
+  (define fish (standard-fish 100 50))
+  (check-pict=? (flip-x (flip-x fish)) fish)
+  (check-pict=? (flip-y (flip-y fish)) fish)
+  (check-pict=? (flip-x (flip-y fish))
+                (flip-y (flip-x fish)))
+  ;; borders cause problems:
+  ;; https://github.com/racket/pict/pull/78#issuecomment-1479939570
+  ;; https://github.com/racket/draw/pull/26
+  (define oval (filled-ellipse 20 30 #:draw-border? #f))
+  (check-pict=? (flip-x oval) oval)
+  (check-pict=? (flip-y oval) oval)
+  (define (get-bounding-box p)
+    (map (λ (f) (f p)) (list pict-width pict-height pict-descent pict-ascent)))
+  ;; proof that "scale" with -1 factors is "wrong"
+  (check-not-equal? (get-bounding-box (flip-x fish))
+                    (get-bounding-box (scale fish -1 1)))
+  (check-not-equal? (get-bounding-box (flip-y fish))
+                    (get-bounding-box (scale fish 1 -1)))
+  (check-not-equal? (get-bounding-box (flip-x oval)) (get-bounding-box (scale oval -1 1)))
+  (check-not-equal? (get-bounding-box (flip-y oval)) (get-bounding-box (scale oval 1 -1))))


### PR DESCRIPTION
I'm not actually sure if the contract `pict-convertible?` is right, but it's what `scale` had and it also uses `pict-width` and `pict-height` on a `pict-convertible?`, so I went with it.

(Is this one of those contracts like Butterick's sugar that automatically does the conversion? Or is `pict-width` exported as a wrapper? Because the docs suggest that `pict-width` is the struct accessor, so the implementation of `scale` and thus the flipping functions is actually at fault relative to its contract.)