### PR TITLE
Allow arbitrary font weights in text styles

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -307,6 +307,10 @@ The @racket[style] argument must be one of the following:
        family (in case the face is unavailable; see @racket[font%])}
 
  @item{@racket[(cons 'bold style)] for a valid @racket[style]}
+ @item{@racket[(cons (cons 'weight _weight) style)] where @racket[_weight] is
+       a @tech[#:doc '(lib "scribblings/draw/draw.scrbl")]{font weight}
+
+       @history[#:added "1.14"]}
 
  @item{@racket[(cons 'italic style)]}
  @item{@racket[(cons 'subscript style)]}

--- a/pict-lib/info.rkt
+++ b/pict-lib/info.rkt
@@ -13,7 +13,7 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.13")
+(define version "1.14")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/pict-lib/pict/private/pict.rkt
+++ b/pict-lib/pict/private/pict.rkt
@@ -311,7 +311,8 @@
          family/c
          string? ;; could be more specific, I guess.
          (cons/c string? family/c)
-         (cons/c (or/c 'bold 'italic 'superscript 'subscript
+         (cons/c (or/c 'bold (cons/c 'weight font-weight/c)
+                       'italic 'superscript 'subscript
                        'large-script
                        'combine 'no-combine 'caps
                        'outline 'aligned 'unaligned
@@ -1536,12 +1537,14 @@
              (send the-font-list find-or-create-font
                    size (car style) (cdr style) 'normal 'normal #f 'default #t 'unaligned)]
             [(and (pair? style)
-                  (memq (car style)
-                        '(superscript 
-                          subscript
-                          large-script
-                          bold italic
-                          aligned unaligned)))
+                  (or (memq (car style)
+                            '(superscript
+                              subscript
+                              large-script
+                              bold italic
+                              aligned unaligned))
+                      (and (pair? (car style))
+                           (eq? (caar style) 'weight))))
              (let ([font (loop (cdr style))]
                    [style (car style)])
                (cond
@@ -1550,6 +1553,13 @@
                               (send font get-point-size)
                               (send font get-style)
                               'bold
+                              (send font get-hinting))]
+                [(and (pair? style)
+                      (eq? (car style) 'weight))
+                 (extend-font font
+                              (send font get-point-size)
+                              (send font get-style)
+                              (cdr style)
                               (send font get-hinting))]
                 [(eq? style 'italic)
                  (extend-font font

--- a/pict-test/tests/pict/main.rkt
+++ b/pict-test/tests/pict/main.rkt
@@ -762,3 +762,10 @@
                     (get-bounding-box (scale fish 1 -1)))
   (check-not-equal? (get-bounding-box (flip-x oval)) (get-bounding-box (scale oval -1 1)))
   (check-not-equal? (get-bounding-box (flip-y oval)) (get-bounding-box (scale oval 1 -1))))
+
+(test-case
+ "text 'weight style"
+ (check-pict=? (text "hello" '()) (text "hello" '((weight . 400))))
+ (check-pict=? (text "hello" '()) (text "hello" '((weight . normal))))
+ (check-pict=? (text "hello" '(bold)) (text "hello" '((weight . 700))))
+ (check-pict=? (text "hello" '(bold)) (text "hello" '((weight . bold)))))


### PR DESCRIPTION
This commit allows a `text` style to specify an arbitrary font weight, rather than just `bold`.