### PR TITLE
Update pict.scrbl to correct typo

### DIFF
--- a/pict-doc/pict/scribblings/pict.scrbl
+++ b/pict-doc/pict/scribblings/pict.scrbl
@@ -74,7 +74,7 @@ A pict is serializable via @racketmodname[racket/serialize], but
 serialization loses sub-pict information (preserving only the pict's
 drawing and bounding box).
 
-All of the pict functions that accept picts also values that
+All of the pict functions that accept picts also accept values that
 are @tech{pict convertible}, meaning that picts can be mixed
 and matched with values from various other libraries.
 


### PR DESCRIPTION
> All of the pict functions that accept picts also values that are pict convertible, meaning that picts can be mixed and matched with values from various other libraries.

to 

> All of the pict functions that accept picts also **accept** values that are pict convertible, meaning that picts can be mixed and matched with values from various other libraries.


https://docs.racket-lang.org/pict/Pict_Datatype.html#:~:text=All%20of%20the%20pict%20functions%20that%20accept%20picts%20also